### PR TITLE
docs: add an empty page of Autoware concepts

### DIFF
--- a/docs/design/.pages
+++ b/docs/design/.pages
@@ -1,5 +1,6 @@
 nav:
   - index.md
+  - autoware-concepts
   - component-interfaces
   - AD API: ad-api
   - configuration-management

--- a/docs/design/autoware-concepts/.pages
+++ b/docs/design/autoware-concepts/.pages
@@ -1,0 +1,2 @@
+nav:
+  - index.md

--- a/docs/design/autoware-concepts/index.md
+++ b/docs/design/autoware-concepts/index.md
@@ -1,0 +1,5 @@
+# Autoware concepts
+
+!!! warning
+
+    Under Construction

--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -4,6 +4,8 @@
 
     Under Construction
 
+## Autoware concepts
+
 ## Component interfaces
 
 ## AD API


### PR DESCRIPTION
Before talking about Autoware's interfaces or other things, we need to show the concept of Autoware.