### PR TITLE
docs: add the license page

### DIFF
--- a/docs/contributing/.pages
+++ b/docs/contributing/.pages
@@ -1,5 +1,6 @@
 nav:
   - index.md
+  - license.md
   - coding-guidelines
   - testing-guidelines
   - documentation-guidelines

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -65,4 +65,5 @@ Otherwise, create an issue or a discussion thread before submitting a pull reque
 
 Also, regardless of the size of your pull request, follow the pull request template of the target repository.
 
-See our [pull request guidelines](pull-request-guidelines/index.md) for the detailed steps.
+See our [pull request guidelines](pull-request-guidelines/index.md) for the detailed steps.  
+See [License](license.md) for the license notations.

--- a/docs/contributing/license.md
+++ b/docs/contributing/license.md
@@ -1,0 +1,44 @@
+# License
+
+Autoware is licensed under Apache License 2.0.
+Thus all contributions will be licensed as such as per clause 5 of the Apache License 2.0:
+
+```text
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+```
+
+Here is an example copyright header to add to the top of a new file:
+
+```text
+Copyright [first year of contribution] The Autoware Contributors
+SPDX-License-Identifier: Apache-2.0
+```
+
+We don't write copyright notations of each contributor here.
+Instead, we place them in the `NOTICE` file like the following.
+
+```text
+This product includes code developed by [company name].
+Copyright [first year of contribution] [company name]
+```
+
+Let us know if your legal department has a special request for the copyright notation.
+
+Currently, the old formats explained [here](https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/blob/87c5e5880a18068116dd886ad56e1bfc29e694c4/CONTRIBUTING.md) are also acceptable.
+Those old formats can be replaced by this new format if the original authors agree.  
+Note that we won't write their copyrights to the `NOTICE` file unless they agree with the new format.
+
+References:
+
+- <https://opensource.google/docs/copyright/#the-year>
+- <https://www.linuxfoundation.org/blog/copyright-notices-in-open-source-software-projects/>
+- <https://www.apache.org/licenses/LICENSE-2.0>
+- <https://www.apache.org/legal/src-headers.html>
+- <https://www.apache.org/foundation/license-faq.html>
+- <https://infra.apache.org/licensing-howto.html>


### PR DESCRIPTION
Moved from https://github.com/autowarefoundation/autoware/pull/29.