### PR TITLE
docs: add overall node diagram for autoware universe

### DIFF
--- a/docs/design/.pages
+++ b/docs/design/.pages
@@ -3,3 +3,4 @@ nav:
   - component-interfaces
   - AD API: ad-api
   - configuration-management
+  - node-diagram

--- a/docs/design/node-diagram/.pages
+++ b/docs/design/node-diagram/.pages
@@ -1,0 +1,2 @@
+nav:
+  - index.md

--- a/docs/design/node-diagram/index.md
+++ b/docs/design/node-diagram/index.md
@@ -1,0 +1,13 @@
+# Node diagram
+
+This page depicts the node diagram designs for Autoware Core/Universe architecture.
+
+## Autoware Core
+
+TBD.
+
+## Autoware Universe
+
+![Node diagram](overall-node-diagram-autoware-universe.drawio.svg)
+
+[Open in draw.io for fullscreen](https://app.diagrams.net/?lightbox=1#Uhttps%3A%2F%2Ftier4.github.io%2Fautoware-documentation%2Flatest%2Fdesign%2Fnode-diagram%2Foverall-node-diagram-autoware-universe.drawio.svg)

--- a/docs/design/node-diagram/overall-node-diagram-autoware-universe.drawio.svg
+++ b/docs/design/node-diagram/overall-node-diagram-autoware-universe.drawio.svg
@@ -1,0 +1,4420 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="3600px" height="1792px" viewBox="-0.5 -0.5 3600 1792" content="&lt;mxfile pages=&quot;2&quot;&gt;&lt;diagram id=&quot;T6t2FfeAp1iw48vGkmOz&quot; name=&quot;Page-1&quot;&gt;7X1pd9s22vav8Xmf6Tn24b58lGwrbSdp00mbpvNFh6ZomYkkakh6y69/AZAAQQAkwVV07EwnkbiLuPflus/0y/3Tu9g73n2INsHuTFM2T2f61ZmmOaqugn/gludsi2m5RrZlG4ebbJtabPgUfg/yjUq+9T7cBEnpwDSKdml4LG/0o8Mh8NPSNi+Oo8fyYbfRrnzXo7cNuA2ffG/Hb/073KR3+Q/T7GL7z0G4vcN3Vi0327P38MH5L0nuvE30SG3Sr8/0yziK0uzT/uky2MG3h99Ldt6qYu/d/W+//a4dL++X/pd4/ez9sf3LPTfzx33wdvf5D/gz2m534A1mz5A+4x+Gnz8ODqnM/T7qf965//vrz9U/zgdbPf+Ps/ojOncM7n5nmrUDF1xuwgfwcQs/goseg9gPjmkYHcCXNPZub0N/vYPvbR0HfrQ9hPk+fPpNXJydbQE7S9dkfk8c3R82AXxYFex+vAvT4NPR8+HeR0CbYNtdut/lu2/D3e4y2kUxOlffmIGzMcD2JI2jbwG1x9FudMsCex6COA0BWSzAQx/AvjSCl/Tybz54iQE4ZbnzboLd0vO/bdHz4CsdokNAHpp+5/WrCO4ZPFF0mK/MuyDaB2n8DA7J9547ek5lOZ+dW26+4bGgWtXKt91RFKvjM72cU7bk6gU1gA85QbQhDq0LcUS+f3/0Dv7zGgqE9R4s3RtVdKQK1dDKZKEbPFVoioAqNGssqrCdTlRxk6SevwvWSbDdg/fkvYmLXoRBFj0nDNUWEIYuIAxjNHFh6d0I4ytQ+29KZBhxYTFaxFV4sjBNAVm4unZhjkQYpjUYYWyCFGzMPgf3/g7Ylt4bwfQQI5ZZJhjH4glG1wQEQ6hocHIxeLMDGJyQGKL4eQ0cgF30CN7akCt5extYvi9ayY3t3gAeqlrJ0ZbGYRjZMQWMbIvMQbv9uvyVBPHviN3AeYgW8+XZeYdDeNhmF9yFh2/Z9o2Xemf6wsOc+DWB/1ye2ZDr/ncPHaJltjMpNoATzsxl6ZgUuTblQwCt0Yf44CH5i5DvwrdtqNQJ5tWZjf7LPqBfUu+CGdTC5PTalcz8aB8CsrpSeJKzDNtybBHJ6aqhm1Cs3EaHtESk8M+YRKcaZaozHYEPIhIGHYxN8JUiu1oyvATvIY52U1JhXxKE0Y8eJGi+WhIEhsgcSfAjZZm8HCo0+lGh/Wqp8FydJRV+Du5CHxLJyyFB2+hDgs7r1cW2PksS/BQckoktwr4k6Lh9SFBVnFdLg+e6NkuDMJeDv0Dv+Ra+6xdEjbbeSydbr5YYTXeWtPg+8r1d+N17abahqmi9xGJmIb1KSjxXLXuOpPjpOUmD/YsiQs3sRYT663WUjdPGarhQ7sr8dH388+pWdz8v/q29Dw5fn4NzPpKLwvHe9hAlaejzRQ3BZht8yr9GcXoXbaODt7suti6LNYULVRzzPoIBWbSSX4M0fc4rUbz7NCqvM1iI+PkL/eUfeLELQIr596un/OrZt+f8G00gLZc1ie5jP6h5Ubgyxou3Qd0FVTPPvsIXJSWrwA9znLykJQ52QE89lCtjRHSQX+5jFB5S6pDo9jYBj8cSCrlrm9jyly/qTCXVh9+vfln9cn21fr/45/o/kvJJuKqucvZaxdO5rtoX5dySLchFnkBLftF+fLpTXy/dqZZzYc+T8F6BwNNeMeHNVN59egVk93p9UVXTTkt2co6AKqwBWoWwsMfbHaMk6O0K0Av39X5/xOd6sd/RUXgK0y/INTDzb/9QewonAX7BPkICLPh0AcvWwQZ/5yVJ6OPNq3BX+CAbfFBe4wO25PvHcC9wvIL2L44fvvxz9327/NtWv8RfovPf7TuV1N40uhddXQksLTWVCeeRUDO+SPas+XltPA5ZirRFFPmAU2wrsGbpfYI27SI/TJ/XcXAEZPRSCFWZOaE6m8D7xfuY7s7X93+5n6+8p6d3qHRnEvpTSfFUTn+S5AfehvdMHXaEByRtbmQzbRotTwAfsmcY0EfnOCZ+/tX9633wq//B/nRzv/Z97deHc2F5r7eH+hNVWkIpvs4lOiDVeJ3ED+QIcfVlH9ZJvgWpfzcGH6k0F+VxoUpGIuEk8uWfghVroklNnLXxkjtis0yhD8QHmqPwY2su0hSTYVe1gY24M3S3ho+G4pGGdiqK9okRHTyl53lBMKx+3AW3KWULF8XRkF4fAQXAyufDFna9Yd463CSoFtVcXmc7zKuq6ueBnsW/jyEprrdeGqz30QY8iwJu/w58hS2ENQ/wAgVAE//X87G0ou0mRnpIBuGBliVrKcpKhpwhgSDVFLXEkWp+iZ66XFUYU/Jcc5lWhgplPpL2TPfL4PP270/u9bPyvNt+ULTww7mwB4LSnh+9+BsqrKlVmJBDyzRb9kVzEqQd13wT13PAFrTvw80GcZzIQS5zYUk39UiLtImusAXxtqA/0hF4uaxd16VNQWyq8smt3HlYE4/Bjw7oN8bCFpX0MUzS9WOY3oEDH7w49A7+jP3gNlJxIPeikIqFICRO+DhSUWgG2QKp2M9/IVLRtLRBpCAMsbAsMpVLg5sRO7soEr+G/THZmg0RHvhrufcule+fN8n3n5/en7v/qMnHc8PqzYh9ctMtrYB6ni/iA7Z8JKsHC6my2WxsbIwfbWK760m1xNC8obN6ymxyVFS19xnY3hnKtRFzhDBediQtYqv0Pj4A/38DjIo0ipO1v98IXJQ/wVG/kIMuo/3eO2woh4Hu4KSvfud99+JNBjlRde2f0THv0SH0lQWM/D5LkNDMhy0k5PXU2EdxkITfvRt0NQXFPRBNgEubKHdRZse2rZ210ogzmAhuSv48ZzQ0SUU9iKJpVtkOH0gBGWXznmWxQWzrdx++LR6/fttsnJ/vws9/vgv/SrbnhttAmgmweoF9Fa2pbXvviTLUAKmEG+C+JgI6NJdpGMQGOXm9T7YwMAz+AX9/zq/xPtyHaRW5dTXgOuiQkumVkxltd/Wxq7pEmnsoErHjqfPaRUwVLW0xwBqqqg7EDLbNpoMNSXOMv5ajMVdy5Wyhkdxb+/vNl6/Lfy4f3/0Rf/36/q+H/a8rsXbIOCk5whZ9QbjJz2QhjDTF25v/U2AOGpmS6J9/IdpRYEb1/Nbbh7vn7NC7YPcQQMlM7U8QM8C9qnp8ondkN4V7DlG893bUvsfcS4Q7DSUjVWUHeCuIz8Ez+1BMcGeyITLiTuN9QAEiQoc7FfwsaE8ae4fkFlwLXzXXAMpjFG/KdyQn3hDFcc68LQ02icIXRX/I39kmTICsyt9XeNiF+E63u8hLmduz4b0jDkSsiq77LLz3Z/G9FODLFnigCF8vqzk3cInhPLGbqAtEk7gu1m0nmpQLy1KNYSQTZwvr6ki2MHsnXHFQKeh00647YZLUl1i6ub3pmnbLct7rQOo9KFbcjSRdeKzKFh5L06ds9K22UIHSNz9/+IVbpT6gIED2OhudC7GCPZpuGOZm1HinpjHpK0O2vt8YIOBZa3j9qK/cYSJOlnbyN86nE3+oN27gxgSsilRFP/k7N3/od66ydVdA/ZunfuVOb+3az2qcymgU/3pBLYZYBUunXKdRwThx0cblk692OIaw0OEJOFdgUaGTAS27lZ9H9bRVHOyjNECbMnSgDDsKx2rwmWtwoXK8JkcTyuODn1Jvfww2dQ5NEQ/q8YOmfy93gRenNwH29yTezM/kjB/vbSR34a38m3gH3sQneMaPSx4oWp+AK3ryrANj95/QKRLvpV3QvbksoTnsDqM6ubhX1bNyMf4muPXud8WT0fK7VikNEnLXTLscGz/vGWYc1OWtVUs/qB3ksHk6VVFPbXpij29iO6hDm0NX26k+GSbLrz0r3ARBugp0AX1W9pbJ21ue7wc7CLG+hiAkNzHMqQ7LokqgB5aIRZXAURxnVFdFKUcDz1UBNi2BrJyGQ82X5Kl04bZCGuhWueDLde16mQC+fAziELxpqMhPW52KeWXsyhKdQeEoYt4Nubm2wXTdKOfsz1W3Ppiu2iz3DFz/Ln7vpy2bYiA9msqm+jHIJLVU4qi9eVo2aE+8DMp4QyKIQyVvezzWCuPSun1iZeBYWpneFbWxgAN+Y6V0BRsUND+NYUbiWyeoG+wXCFM4w2yoThuLvH/hZUTFD8NE09jiurr5Ctnj1Y9dmNPrYH+aIiglHCCK+NJeS+to2sv9qUNQQH2M8KW9kY6Rw5f7g4cggYZ4qMwrOU2UlFfmFTYAcPRX6I9Q39eaRf0Dp8CgsZgMcR6R6dsxyPQhOnb5CuNFVc2TpDo7GniUqekaFm1qwipyhRifbWzNwY1GXTZ9OlWzicOGBLgBjQPV17ncjRqgJWxcwVNxwkhukqg4f6ieeFZpbRmllQQ7IHCCTcmyFeumRn3QM7s8F0kvK8YHy39Bv5Rx0K1hxLhRJmfSUD6+HLeMk/j+HdovurZ6SOmMLtnWftUy8tkbZWbVMnxd2RkNN4UxPd6oatZUJV0GXST/LQvD7cw32y+Y3fojZfvZNI0hGKM8Wq7/63tdu7v55fd/Ptpf0neH8+3+5z9ImWkFq+cpiEEbA/sl+s/0NpmVHgwqRviU5c+RAAxb974YWtlxPXeMhhyG0u94sy7lwbsC7NksGOhw6IviGa8NQFmiujjxmOCGujx6W+2oaYnz6eHDDafVRL6qr08PNPZ39wlwALJGPInaw7ehxy2GHrMdcI6g00MTTcnmWuWGm5GtcQxRSQ6b6PGQAMdyh/xaJIr8XXS/6W08DgIXNOiy0opBLEgE4R/xgSfrX6t9bho9KnoKduttHG7WgOfSgUdcS/DtiCynsgrHFtVyjWWBiTmON3krOS66T3dhEJN1mR3TjVMiNjizOrLMKtsfPRGzOhypsBTx43KqdXpOFYZOAKd6ccGob3zYgg8F7tT/rv5+Xiv/e/iv7/x1szr3ft/9oZNCsxbRDkNzhonuAjuNBbTTFQKqMjimHQeqZbj4ZlPCD9Sul0hVravo/wcSQQRv8HQiSOSvlh3R6CZJPYj+mQTbPXgp+UTQWlOhgL8sMDKpVWkSUINKjWalbLcWBrbj8s3FIscKb+stMzg2dk2GJhrBksi1FFb+uLas/JlSOpi8dQLLdaIw+WluSrFdEHE0pSjUdaLeAvGBHVIAbqcMQHstxlVaG6pUWHB8KhV0i5N42vrmeZ3GYKGRb5WF6frPBv0xaVf8chVZ2m0JPAUNOtXWpiJepj5FU2djgglqvEvky8dic4JeH9B4hB/GODMUZpFUU7+YEEFEvDoq94ZPIy0G7KUdEeNceKAuG5zBrHDqFJvKzpM4txhxISNj2HN6F8GJ39mJG0fbKa+WpNVIMdJhhLEphp0UojU0UcKepL5nGHLzu6qfkU3NDod8LybV07Rw9pGcLds+h7a+bIH1JT5QG5oP+mnN0zYwtly1iRtve670yYoPxSvNhwgO0TpzTaDHdQiSuyiVz2sFu5vocewRNOgm4CsuJ+gvMOSg0QUxuWIqzcsJ8svTqmxjBBXXc5WhgvxA3aE2H8s0gaNpMDXdOgt1PoN4m8VH42PvsA3Wfhwdj21qMmbARgOxxLSRaFvWA6EQuGxtohAcZ7/1nd86qY1YNUUettREB0GYI1vwUh68mDR/l6bHBPXwrGBzTpje3d9cgEuBL6iR5qwYa3kB69VWN7voBlY4BXAyxxE18BySrAbjGAfHOPKDJIEYRyUWo76smcM2kQ+bcz753uEdetIVetCLfc6ZaRTt0vCYPe7ZtX7maGeL7IN+tljmW5YG3rLAWxZ4i5JvccFZxtny6my5QlvUs4WOP1hn1zY6y4UfltdnCyPf5eBbOGCXeeZeni3BBd0z9wo/RnZlsMVFZ5lnzvXZcpmf7tr5B3DNfIuLPijwRPQLa2WZTbfu5MKva5iKFlftQ1alaZ4tBUar5CI7FnZE+FvwleKnFioGowWWUjrTm+qDmyTa3MznKnFHCZQ0Ekg9oAaDOPFhpVhriVe+NnMlRh4JpQb4z84/LC+xPFrJiKHI9++P3sGHrw4WGlLn2GeuceaCc6wzxzlzlToBIyFXtNcmV9jBb7rjXuCs36xEi2iM+/SihV7UF9KYUiuphvOyRs+yMZ0jtY0jQ/lMNl8/Q2QRKnkW0uDI/dFtnZZ6fhqgT1q1bBblr4vPIphGxiVWy5cYz1l2ROKGKZwqEQJEM4V3gn+/1JTexIGe1pPYTbtbPYpImqjuhc0090vOVh0mZlNlwRG7SmzAiYiup++axkHQwXctPWjVYzFmIXACzbOF094+VKAFJ/AzeffSOls60BLMrb9Vxb3gBYVWJTA3r5ExqcNnBdcFjvJSLRmcS3DFFXoaBd0JmKCLMwd7xtD5dqDr7CzPCjea/AYXHgx+BrwyeGIdPR/4DS52rLNdV2euk//ghVN2kbXiysUtyOkWt+sa3mKRuf42fE35W4Y/R/gK9DP3Gi+IjrfY1OVMaKcv0HqChXKIwW6jX+7kLwUcSc7q7e+br90uN4yp7fIqCcXwOi+jIK73DZAOm7Wo22SGUbbf8S96B37QB+/4e/bYdSG3KtlhIy/WgWyW86FDBcqyD5cUG9eIA14KCNm4kVtrZFn2GBo+GAuaPH7YKLCEkpVcGTyGiSOT+MGKyOSqHJnU0ZWzXbU+fBuhYb02oaEyld+maBTcQMjz3T158UD2vj0J88pPnTDNO7EV3zILq1zouj4MHCKfT2pvwheXYvWtapUvNe2warFTyhfzwtzt+iZ6+gEbOtkKtinHWopfvyi7AfH5fC8NDl7amEJv1TZVz8a83JpoLmBjwBATaack91TtVqzgUFmADOluK5cF5TAmDSNIUm5/+NbZ1ZmfrGpJCPSEcVAaR6jjK86kwg7jFJdlGna7oIsFjK/+8H4vEKHFHXyKlliCuExew7DMC5f6Y8p1bg4lKlzexigTxECAj8PKE0qaFLJlDkFuaSoqzGNuKMwwSs/RB6Gztok79ra12M1T6kS3f7/Am1SrXHZVmZlYEwYdNqG3PUQJ8N/FbbsjJ3L5xa2l1EFGuioKRgXqusLYH3PKZwyZBPM2a7DnIfQDQXgZWSTrfXQIydTI/tmvvZeBkaySZ/BhTx22FtyPr75UcSCTRE+pFEwRjrUEEc3mQGbGtKMHMm8dP/B9kb9/45iwPWyqQKbDhDF1czzXv3MY022AAh1oqjZBDyVzAFb+fQxf+Xqb0SVs0+4K6jn0Qxa44JBr7pPiuWf2oLyH0+rJJo3stOSzNvgepqZxnDVi4EVVGIgktSvKjcuEa225oEtb65V74NlYr0JsOcqeWQcxHw3+sQxcMZK2OThgqpzfzpHy2BatCD5JahpMSZeQkTNYTvsw3y0AaG575TT2oEqN4uf1bbTbRY/IvBrmLiGEwfZ2xygJtD7X2UVw/vh3nF78Fh6CPfjir0s6ocOFs2JAqvAAbeh5uQf0OnteismzCpDFCY5R93vsvMMhq8vYh0AbRoc1tQlIgV7vlrpUArwwLw4j+vIF3fW4B/ECgn0AuBjVeQxEu5Im0jBXBr8CYQGv8ZYhLw6rcPwwfSYXf5X5rrYRPmB26YpWLmzGMbKJrDCtAk6ktRVmM6iFGptGG2pknCZ+4CnNMJUnHAZShTmhYrwTp7UvscqsvXxVqKR0dhEH2XipB9wiD899+JrAfy7P7GXhImU7E8pnAn6UuSwdk0bbLeR6+hDwYPQhPvjZ/EXI98rXQE4wr85s9F/2oRQPEfPmNN2ft7eBJY6HbGz3RmkhTMiqS4dANLcsIUyHFxHCEAjbUT1s7SeQOzugzff3TwOUc7Kht8J25G/D9RcuUY31tQWrFkl3s5vVmDtFGbSrUqG3quJkXKaYV2aqqJ8QXWdpoSLn67MFLptckhpLXHVJtpAKz7xM3ETFlqRMnA8FmrCGE9Zzgg+LM7e2ObqZK6yJooTNXFGKEm6h6s8/J3feBtkDo/KOrjEZNGnmGSl+KF4u2VFCjDHW6GIB5glibyc2WGtCbBU3NJcLiAcJvMTD++zK5Vmh5dnRctODWk/+aRu46Dty7JQ1J5jgG0MdeBhV8wjh9iaqaShaObzhdrE92xp6usFCIyqMkcWe4Ji1J0xiGopfujBC18i80QFozvtNeKjiYIp3zOV76nABW56Yi15atZc85wm6pwfjPN0oc945jtH3dPsslrdId8DA3prJDvh+wUwsKhsQqLUucc9eqvhV6WBNL2EuoioGu0EgoG8fgzgEJADrNDojNtDmby5OxMN9pxVB0qN/rfYweY7Wt0Ykv5ahMyLHkAT8ar7SkAh7ra0UVl7hn1X19Jpp155w1hK8osY9hwb6Opc2u1Gd9P3RpySc2Ek3kU/twJbpxQp9WMHe4cyndgnAzzXld2eeuErtsqFrnHUyAv+ddEEvXex3W7jNUEM+vo07EElLY+PBLmwqzLx+4I8vLMqR79TRLHhm4S2yJ0Tu/0KpPmYlepmk2MiEpxSAbCo65hr30JMn5OMbCtezqcLGemZRlvSHNiELcatmjSvzFrvQNIeRc2MOnGwT+KMcjWnEC8kusXdrlDI1gqOKwTLgCK0AHysCiJIiqZ6H+4gSFz0P6t9eLlFE0oEN1bAl24It4gvcOO1kOBgqtUuDH8DVih5vHLV0LdyAfYnjmLgvHZwIm8azru/sbaAtQF7DDwilzSVN7NnvUgvhQpAwusqCabAe5i8LDHaOl1AWWJPLgjwVDH0ZVIM4qhAQ3YqRABakPYiGYEN9ViCcamXCJgF6rDUBsxMKdwn2AQ3W4sALwitbMElAgAkWWKE2JwOygxEkxAJrVgY7FbCJkzHsNRRlJYnk4MQDhf4im4FAcgNcIedlwow9VbU1DarC/NlTVRj2JHkHij1JR/rwOTq5CIYQbWE2nn2rGF/hvWumRfvvF4raEFUEX9hYQEu6aPSzRxoWIwiRWxeKTXXSlIlQs4wL3VDIn7YoBjiGpzLh/3FChdzcPy1Pi3V0jDmeOOz/e2f8+2u0/m0df178s1/8tn53jgOhNI5C74rI+uCcgONGbi6imVSS1omsGAAT0laVfGl70jsbamH6xsaL/RKgnKoMTnIX3qbrTeCHG2S2bAMvrszUvAM7f5jUjKG6XEC2cQ6OKCDbUgg3V3/rI4ZFVcvsND2kd3iR6ZltfUJV/gT7GWy+RpdMDI2LhMmw12g+huA+PGwlUwpUEQZr9iu0wnnIABShg+EiB2OJxzW0cjBI0dOAlUQ5F73Z+HwpkYGTs6cNxwVPgIpRKG4vQmAExI1+4/BsU5SBx8E+SjPPnLkdwz3ID80iYxBJUDhBxEKArtj5JTG3BvJfIfhRh+Kn7AM5fYlDATC3KRf4yq5ZruRrjCJqK4kgfhYHWGH5sYLhSlpsEEkAdvXnYPuNg9Feh2kUPLfsSQPqsramzOSUhn6KDhY/fp+NVtA0nQlc+ZejMIsg679yV7LZoMtw7XkVKyqq72xEnJjQBxjc9saqcXRsEZalDZZKOq9tdWL9EAATEbys9D4WgVL4dwH0/kc0U6uKfUsPVnqMkh7+8PGSUkTEXiQBYBQ4dxwcdb6sTqw5JEAOb74D5j6TWmIVa6a1ayHVgVVA0IcLJPVyKB5oc6Bh81g6joo7l7U3RVrVtUp6tvjlWlGX71jlnycC7XBwsrwF/jrVk5DB1MPEH/3e6QvCCDwUEBX2PLxWABRATMBIip/l4veUXW9BvTm0C+YBHPgLspaE/HEs+G4WVxhrmvzilSiRyD9ybn9FWTspMZ0kzJNMVLyZJ4XlQYoyp833yyozfhzKMQ42oZ8GmzXdcfvCMwtUMGwSHLnha/3ltXAxVsXsFteashBXNYQAXtgPhmEcoIr8DIO38I5bRvCRTl6T071juN4nW9jrDP4Bf5cD+59ScH4wi3Bu74za4LPJW5iNssX0uVM7gYGpKGy1KSttB7cwGyI6GXWPgHdWGJilJyjfr4E13wp2KmIN9hwbD/E0UyatJQAVY8XjO7DvA9xVtBuUuyCKDJgiSHlJNyisgC9zWIcHYF94gAaTXH5zqBTm8k9w4C/4uB7NEOXb33nfvXiz3sH1qbn5z+iw9+go2XvL/Hpc9ESwR4pX+jnbdY330CpIqoljLLVjqxabEVSNLhlBnAJHaG6VVlbRddGSmdugdDi2w9jmPTPaLWalm7Z54apFkUd5vqLtgtdLlYAwUJyyUy9M275wdF21DKDwXM1ghjhqFpNr7zydXU4wCWKgHwmuD7vKUuAYN8Gd9xACh5kUEyOgoIpEBQqBQLc4i+CTOkKcRSCRhQXt25Mq2HL4oDRDiQ+lZEOiCGQoyi4Abxscn8Us4CCpmkpiC/rxWXygFFCoryTOoAjITHj88EsHbzErfqmKwz84FuPYCHTBQQ9GT5prKnHOJjVL/dLsZZIXxdRHXudvFU58tmB+iFQkZ+8HPDBMNTkoJqGXHwNPE1wqxfA6F1/ZMWrffONSLnEyl4SWrriGjFXdMg1t4TXgZWURxDh8yL4SlqEOaWAjzNQGLVLHtANvtQo70LqxUGUgWzaVQoVWtg67WIREQMmPsTG58SCC+I6mCExCrsFt2AxyWbJOAxzUFzUIvv8eqEHOXMhzNHJTmUqeiVGDJHuqRcCVbVD9kOFffH9d4ZeSEOuMFYxJq3GuDRZfjcEZo+U0Z2Bgu3i6et9xTlwMXRJVuPUQeuASlO6EZz1VGthKn8NJ9rvyeLZwz5HDTXgWvuhBgrdiIhJFHE7Msr0KYEtMftFU+Soz13FovnV5thUep7mt2dZx9E5T2Ftzm4EfjpC3Uc8PBDek+xm6Oj3yiHhhePigfZQyULpkTqr3EIUb7+AHhWX+Y6rMU/CSJtCB4gPbI/AbJepT++nDMaqwCYnxOQkB0QmiKnzhBhkfb8PtS+xdO5m7nvVZkpZiVCmZYUfAwMQVdM4XCp6LvSpqRbMGa+hCZ8UmJgUrwZRyVAVlqPKYpZsXrYCHd7OSiUtcSEKauemmZ6tw4OtGZpNokVsKBLikcoOUllwWZTYRZHblLkwQ8+aPaVOBFISrUUBdosCFu0RVs+Q+Fry/S7/I/GBALeWYFT3LRi+/Oanu7pPFLtoJSK1RBE8FM9voMJ4icmGwI1JPm8oSrxCejFWnJJP7GC3VmhADqZLroSNz3TMjo/QFKFIBprr4QE1SkfYdklrZe4Rphtd6PBUJlV4RIV8WweFcoQkL6yTKDRd0SJnPMphQBWR4QjD+TEN+NGmkLLINHmaJnhk8OblFKWZeVjQkeJ5VINbdgscHyX5XVgxqsDDJOVgUX/FJCkZd9KhZbSN5h6SBhFNk+U1nqaRqBFSzjppNzH0OOsqdVEc1mszAXjsKJEidtVzDRULBoaMmJxMek+eZMp4RIq1lBxMeNhETXtXeFFWDu0sqJUan+qrAUYS2Js7MQbAWYqqqlHCpslDrmyplEnI1+bx68DQNmddEcABzAwYIAEkLusLkHqTyTdsUTB0tLTU5aSmkjipHp5sYJ09oozZYo+ujCmkKq7CckFFl+pLG66lpAEBA+44p/aJkeGWWmqIsWVp4MtqblqA8mWk7AKvUhB8l6d47rrcBWESvarZsW37EMHDglKWCTUEaaFMmxIKusyBlIbhbZkGblMJ+HqatVy96UCDQplK2h3VsW+rYSqT7e/Exy0u2QYjtjqfRPfEzk4ZhRy/fi+o4ympRwCku1l2ihpyphQDggG/ZpwoCqU+1TAWkOUtOJ0EK0uxrzILVSWk1KaDhrcJduA9Tpu66JAu8Y0j8QJrCIP+ieCfUpzrlJNKcyPSHETonTYHE61xRLECAL2yoTKFgMVBAlPZDeW0uxOMjjXArqhgMd8KTwGqpcS2zK2klbiHMWpqRab8YPfNA3LoJ4FIdm9kVwkWhQhl+jUUripn33Ydvi8ev3zYb5+e78POf78K/ku35fAqoTsG83NTvExfPi5dI2IbUQCN774lQhRAcKus7wmeUe44+5ye+h9Q0g8ydTOCwa6YcB0BxyFOmD69HkLKGCSWClLg0ZuxupHMWB9aQnDQsyHY3XWm4Cm/xu+1S+kVzz9r3Dptw46WBaJbpj8xI4ze0jl9MhsP6NGvV8qB8D+tAlWSma1+UEZ90vSuzOUzpL3elRiyT8atMBBCHTBDipVSRaINnv0Zsju3FMUPVcZmWPQmc4bnBMAKuNq7kHEO16044XVGWoENp1vxxkiSvbOnh8PZT2yQvNjZqnO7KqpfFdTbHPt/PAcpk6DNsFK5F0Ow9kMNXWAwryH9VPuaxITYOhsNoJGhWhOy40bgl3Bc+w6uX4GwWTMSAarxiK6eyW6DhEPwUDR4Nx8FefNbbBd8POYty508Vhaugjfoou0vR76tz3w2DNZ1mko7N0yg1obdkH0XpXcv5Mp0HL7Vq9EThtzy2BziDr2hkChyEkFZLlr/JLiLO8tkxJpIlTNKs/gnrayUrYuq5cOI6awuoLvIDrysShlTTLRkkVkwUs+sKNCeWJSREyFIiBM7aA90tFdh/3cWInHA5dXRQ501BztprtSgbL7kjxwqGTmYL8nf+azvifXbpYGVHNDiCSlBNF7x5DnJT4tVz71mVmF8CsSGOA7+Q1iMPzk3NuWDn2AqIVNjsqxnDmbVFB7eX3r0BHrwBHrwawIPw0LrGRgR3gA7x77zDlnQL1PAUEVSzSd71Rz9QqwbBVEs/lZV9AuN/MNHXpRiTdIBUefkiwZcnnXmfXcvZpqZwshLuVkaA1taBsq09lC0OZdCKtX1bjHzLxj7NgYrHpVed1dWaI2dOskH8Yan1eL/braMH5FVE9+lApNpAdFRZKHTKcKRnSddbIS8vv/KqCIe5NM1WXIcNbpEJqnwJv7CzTn6cqDrV2JK5Ea81C+JNwk2wRtN0hHQrMweEojc4IMPJC47YMdVVlFxPpX2p60WW1g1AXaoyC/KizLIXocL1alj67MHwBRd2eRdxUAZT6lMBtM6Ncs9VYzaUmw1tIIhbEyh1psy7KWuTNY+UyqFbkNhUU4FnR2KmNiWJ8XHI/Pal+FiOVovSHDCPCPaTVGK+TwwPC95CyqaQ6RedxyIF4Un50aWi1S9nvUuh0GminAaLIeUocKilXvyPW2VX5MwqFzp9kmK2XvQqIXKIUNfPEda1gRfgCcUI3wVmw2hOVk2db0FCIAul5fgZpIBcx7mTxibltmkn/qYW6sOimxfJ3YkVSHwDWvWRlkfmCYXZ7Z4232SDEOeZdWEap85V2YzuuPo08v3dfQJTackxEjsb8qUXFZUbgDJhhJQYg5mKbFfCkRNn1nQLG6A0ObKvyHf2o+QX6b2MRsmAQi8U+o81B8IOoe5Mghx7db5kTRJHqF4gC+fQ3cslauYkNZyWWYHgkB/PD8vqS/0v0gMaj/rtOVJ/Gnu3t6GfzV0Qkn/V/FSUhwMUWtBRPWZAW5Ks6WirdpTKBPgi/aPRCFCXRZPSnDEpzo+jJFk/ertvQnJD0A6LBWVRZvTi5sHMotxomctEMlJRDEtAx4bo+iVMPgUSQ5ZmzfK/qC6rGI5MCidbzS684rbIwPDQzyzzNmqsmyaXQpzBr0GqkHnhtTgQEOxB6RFWm2zG8gvhaXMWzsHNLjxs6hwDqDl0bLpYiGYXSD1YcKkdWoUIsSuvEbEwACXX+QWXS4rh+CIIIcZWjW2DE2tgl3uFTl9g+UGMpStkrblYexFuyD70gY9pxw2zgdefBzfMw1XeBGnmTlTHjBwUIVqx9rYY/oMJFdVDyw0CGFSOIgFaXV5zth1dYow8GgcxC4SZJf0aLVVQmbZfd2U/S9ukoevE+WYIggSkvTgdKCRrUvbG1OSL4qZAmpOzIPVkZW8KpSeE9CTtqZYozHjd5d1coHFaW4LLqnz/76//1n81f7s92t8/ffh6u//2xyPJ9FSO06M7qPO0SIemvZavucsoAFW2v7pv653kfIgmWIB9mCQMFFrWfSfCAMDFoWv4gcMC+Hlx9cE7/gedffoGzbkh/gooeAJyFBOFLkmj1GQK0jg8u8kUGjsHjDljjJ7myoY4mpsqcUgXGc6TDSNhucm1yINnUjFo+UIZUl2feVBqpQ3HBqM1ZC/q4gL+JW35EWtVr66zoHV3bUn/1Mj3AuknXMJaGfu6LViH4VdX1r6YFM2eb3UStSegFoRHQFFrVFcELlmnxN5w6mtVFLaEaHUkjT7TG9jJsLhqIsUuX6YRJKbmYobJXKzz1HpJAtalCXhymp0h4os+GZ2xxkdrJKKqK6nKQARWZavcArWYQE1Ua63oXdFgKezIGlNCnASvmPEgxtjtY3dUNdALYUmAg/MTdc0yHgc7zmcmQLcVi1zvM77qyiyNDZjYsiG5kQyadL8MPm///uRePyvPu+0HRQs/nBucOuDE/g/RIq9zYwdlW+Q1FoBxuJgKb0wK8KRXke/fH72D/7zexg2W5EzwqorLYt2MLUvypR3YaFnbK2Np+xq47nGiIbqOT+prP6gOQ9+WztQ1zwHKkDc+txEgEo6kDxtMYf7OA260f1aFKdjKUekhamgyOX748s/d9+3yb1v9En+Jzn+371Rg20uSiSwKICWXTIFYwtv6Eo7O4rG7LCSItOWpOybX3KOMbn4+hHF67+3WP1Kqyf5+8+Xr8p/Lx3d/xF+/vv/rYf/r6pVDj/P5J9n6tJHyT+IfxoO1fgwA9xyLcmH65ZTiy1UEzl6gMP83XuoB69/Li5FXXxP4z+WZDdbB+t99hCbAop1JsQG6C+aydEwabbe7oHwIvd8Hv5y/Avle+SbICebVmY3+yz6UaF14tjlNLHRjBs7GENG6o93oltWCopXWFK3qJYI2ZdGyOkA2ydDz/67+fl4r/3v4r+/8dbM6937f/aGfY5eTNlFR99gxE+CrCF0y6W2VzjzESdMQYk3AV9+26CcwDk5Lemk0P0V2hXCprPbwwrbpdjEiWufiVFJ3SKrbcziESlsCUL5ae8qU2bhduPHidYnwORPj6rffyjk1HUeF9GJSHdV98T68Wvynsv5qsRQ1gNApMg23B+vFiNBlfUc8GQyT2S5Mimyk0SyU8sqFxToO/Gh7CPONpPwNfK540fVOxTRdUxKqomQWjag3uEZY3STQi7TyMKaLLQlXxhTXjDRSxFA65QQpNJnoyMT6w5RUC70jEKzEVhU516+9OmHvZGHyF+qGHlUY3nF94yWBaMb0MQ42YXUX4FDFGeWxesRzXBCoXDWNASkViOOVHm3LrsKsY3Bh405ufLoAaXCRY2DA+nsa8JBD9x08e9EoSuhVWhXLyS5evYKZpjFxRgpGsxjbSxfql1MXY1i8s13qT1zTpgVYpu0d+jc8vWYZsdBiYu1i8d6J2BbQhlZDLbE5ypQBRQEv0zPhkFFNxagJ+UI4YXd3f7UggXbbIrHdtqWcae0l48Bpz0QtEu38S3CvqIOFr0460T6qNimTS1mp8KQkIpx6nTJNr/F8dIpz4rGvkh6LxWkUWoe8YMfkRaqc2jgXrXKEV8QtC1N4PuVQ7rnqahdy6dfuzklZCvHKLMuc3oaVM1NcA9v2erlrG3X3sUXaxKEgLXyNuoDGeyBS/QqpvwxAxJyvVGffXr3YmCYzN2NpTuafnnaOUBNPJMlmfRtCdPk6G49nDROZW2jINmx8LWPvVzroMjyS5Yp1qu0827X4Qayjijdez07aa2cnc469DyZfrkZiT2+20dS2Ua3J0+iOS0eFqVmkttMpWzhlgRnOZ1IkmjehXvLK4AHJI+i/8UTbUIBGE2lX6mm59s1LarVeUl0VYKaOWWxms3lgR2MEmHSxmW0yMUpbMt0wcuPmPbAk1nksmqc5JDDrOiTESd0VmhgkRM4gu0y0BVkkzgKOJKyM7C8plI5y2+TCKmUTKsL4RYdDdnOHGp9EwKCoGUlLswDEgdfhJxlVgb9ruelF7CIyJqCIUFWB2lIIuGxPBYW1VUwqdNmXAW257Ae641pTwswFpVpLNFWioNoaqonQfuZjRvF5C9XUZ5m40ESWFG01p14anNyWGqsfj0Yw8GIfb8kewyqp1JJCbWwX6GFO1fj1Zd2rt1ezhuEMVOVvsl2CGqs/eyi91nl4TptrrsWwyyBp+DQ4JFEcp+tnIFsEqvOt9GqA0ivBS66tDLVeWwZD1dkKdJGXLpo4MJJqES6LLTGLdYLa3C6dNtIJAIGTK34XiqSoHivnHEfhGsLgA5tvfYvQ8N+k1zjSq+pN14uwV2cgc12CQpjA8epGqyeAovX1kiTyQy9bU9Z1Xu8DwO8i1/mNgwbgoPwA+iXXM89sOnQm8y5xdUAxoEJYFqee2ATAzsb8u3FOEEZttC5sQby1X79N//ICzutTbba8oNHvK3SAqpWvphvc1SqisO0rtQU3a0Dh408ZuleoQ7JBzGc8dobvAfnprbM2FmyH1KbG3mdKkOYk+TFtcZCE370bdD3IC/l6gIubqOeyX99arXDhBKem+NHhAH5n/jxneWiiNqWk2eXCmXzlu3IMvgpzxpDxfaxH0eT55LgL0/TNJhnZJhG97HoneBqk5hnZJpxhr4sKciZsCBMLDwymMXvLZEqEEWnLxJS1TAYvfGwZ90juvGOwDpI03HsVHVJv8nEA+Sh+z/Wi8dU1M/ExD9HYjwlFo/iX8ZUrf0bH0E/4N1MyoCMB+30O7kJ/F/wCzcdbuHglshDe3hZA9VXek5Bm9SOQGcaHm+SI1lcRbHrIHnQdlp+0JCgWOcNgdnZEI39yTi+ug8VGmWcJLKOOJsUxwoYuyzShbHEy+bDCVQdZ9QK66ZKpMSCnE6FFBE7FY5TWRJwlHo5TGe68UQI9sETcqQSO4jiUE7ILblOG1bswrl3lNlQyrsrURArQUSxHwLR2J6ZtouetrtRSKVYtGKC0QDMtqOrdJUXDjG4iwKZ6mZyodi3S2LvgSdeVYfFpitQlaGsaAjLUcrjOtXmpP1whSCQR5Y69xzUWef5e1FQOXGj0A+OhLAtScJTfF6ZKmKdg7sn1sbO1Wjo13nsBjSbxMbiDHMjOvM7dQfLPhAcv8GDD3PjDTY2sXEc2XWamuZdFiRYZQbu08nFvC2F7IilP0/FsLFowa1iKo+ZIDTOci3/j4pLls0U23+0KPQkuDSss0Aql0Ty7Skzx01hqs+FXzWGxA6ftKZGz02zeTitxF3jTe++wgfzop/fIKodc1tvvPUFZfMuVbixOt9vXnFuqyQQIhylE1o0yrTkMBU1YRcU+yrlWHyBvOH6omisgSvbRhrV5RlFIXiLQPNn9eYOJPNCGmNLvg6f7hD3SWf7qHb3Dn95TyO+qsMLFVDtNkcB8xLBVtrvHNZtkCwTELu3LQMKEa9AdCdOaJpYtQX+jkZzJFNadGglT6I2L6uooIQYrtu8TtGkX+WH6vMZbuPF3wtOAVAxiOAOv3WnpfXwAQnoT+hAsPml59jbw4panAG8BEMhuDYSzaLSf8Bx8XAIEcol6CdcFT+l5HnFYwExilvksuCa/fGFSlR8a3gxdGz8Fa2w14YkT60jV8Pes4lxRG/IE4MtHsHCA7GCqljPVmDBKSxZqYSkpjl7OgVt8ZcqInV2qbYJ35eI/Du5wIPbVhW25xR+nfH3Zpi/VNsq2DysARm35qgm1ytgRAphK2QirnGuCs2sM3GJmSGmrn346tRPCAo2b8H8ilWOhPx3dllLXSsHudONKHwwuWRY2ZL0iQTWz8EBVadl5AqQZGYLZk701hvFUlvF6DJdovJlsj0t3Z6fExS/EqDT6GJVqNsJudKtSgsVvgUFBbc/+tOczeWvT1sshhVNbmxULJBrMlCfQkM1zufiNbKiweuYu3YcWpURCSsjSwVFxW5ZIFNEJPvax+MSFLHC8nPQtC7aQCb649KHobXakZMI0AeceMqFTBKS1gNAwikQuIMjosNOGQDJDTmeVFAzEkTjcY/gtvIij5CKKt8T206UWf5p2vhe3+MT4OO3i//MBHK28i3a3l8CMFcgMnNHCiWQC91mkjYUAoFkWSy0+SNCKOk1IdPa0wmaYJxYUIn/0U3BIEGhE4yo69f07/Etr5aAKQ2gq7mOgcQ9Q2RsMmm2eD8H6CMEtGlCkgt1N9ChnxvBIA7KGDboJ+Ipr7/un08ZEmRIGuMBGyt+V5AKMddKIjaDieFMjMJGqn9rYyvoxNjG4dCyQnZj6SJIpP7K6euvz+4+Q96FMBh91DX/8pGpO9vl9+BA9lWvEVFx5ym9RCoAcgg5IKoeIBHczmEAH1T+4sNTBJYjLl2UrUCswmJfX/POX5UPd+g4v5Tlp7lq27lm8/A/UjRnYHaU5puM2laJO54m9HUbEdk5EqLpWIUVjWBh8GwYw2ofSzv4uut+8ydIXIEt1WVmKTYeTydLb8Gm9CZMULH7V7JOaqesI2969znctiMvKoXmVILsQxioRjC7Bkl81dAUQfFUiC7FHnOOa6dS8Tr0sJplZ7nQpmY4vSNVrkmJfF28hIhkqEASpLP5x9L1o5x3b5PB3d4chI5bVAwwxrm520Q21l6rGwAYYJTdWCWBzlPIDnJtkYc5VmM3mAsQVrA/RJrjwfSltMs0s+EJnVGqZk2kT48QDSysWhg80ZtqkoIR17D2+aZEXoEUEDWIVR9pDaxFxKgdwAdu7bkrmbHuVrkEfcp1GorFdjF1U7whklyI6gzoZSvRrSmyXy3/hABdDoE9kBOU0Udg5C0pLNuY2raDkZ4NkgjIJdrdrP46OxzfL++XJTFtaZg6O99HS8oYktr6JngRSDTA3RL6ClNjWIndhC0c2kgNYmvmsQAu1xNKmOR1ZWFZY3JlZ7UKJB7eYsGeWNMoJzer29mx9UXGCw59w8N8xjvwgSeDIgRJT0pYNcxgyeCVk9DTZ8znLaOkJBdPKaH7ibCaj9yEQLPGblH6pUlow86k+kjJjKZ3RYls5naX3SDIP5/kcDJrgMvAGJM+HxTzchScvlbDSzRJeQjGdht7ST96/VDE/DcTdnMW8IVscNYyYr+ychZXx0X26CyG+J2IjIf/UBAIzbmEarrOJSzXTnfgRxuA/XUXLUMQEs+gexgaAYxAqooRLpdyDlI0dQB2seZcoGURQGuCcxzmptloaaMCtHx6hl/rJax4qf4QsGcW/SgtmosjBWTQXfHUJ/gKZ+mlIPw+RQFQuq2QpVq0ovrJ4RfVS9RQ13qJaXDFjs7O7jzX+YRABthIxRL1EM6ZpJpqzRMMAhPMyXA2+dh8lrWHd/lt9xIu0WQ1N1maVntzU12aVJUY+wUxXUAh6xf4P9TdplzFiH+3yNo4O6Rp/A5fKNuCjAi/+F0fCP15BgaZYExYUyC6uzi1uY3+en71D2JoXb2/+Dzybki0r9elf8CNCdYJFeee33j7cPWfnkDp1WKIHQcHugt1DAMUGt6d8kQSJHHgJVT0+Mfuyp4Q7D1G893bl3Y/5y4T7jew50c5dADEkz8FP9aECFp1f1Y1I7w4BqR7yyyvUo6GdaewdkltwUXx5IJPwAY9RvCnfnT79hqCznjPvXDNN8q6Zz8Wb34TJceflbz08AIOluPHtLvJS+oHY5sqfaipIJNss35TQ7JSQIauE8Kyjt8KSt8KSl1RYYgj6an9ol4a3KuZZWIJxat4MjTdDgzM02OKiNwPjpRoYgpbLiiMHR6WuqDkClP5Wc9Sq5siYpvlvzjp0njVHhgh16E2HvunQn+rrzt7U6UtVpwI0mAp//dSNIG/laHOpUzCm6cees/qeZzmaYKjDm/p+U9+Z+q4tSXxT4C9UgWM5JOEPG7NX4G+Vii/EAjBfW12PIAj+Vqn4Vqn4Vqk4SwHWoVLRnGZa0Zwl2jwrFfED0FOPo4PvpcEB/J+1Y+dtsM7UiMQHtoD/1mwtDxW3y560n+jtcsPIOWQwagBJJwBgwU1UW27eefcMTkbEdSrbQbkWm1cvdcUiROdRQEwLPJGKgD4tLPKJHmn6MszTFcX/a4SZ3CzfG9DnfjzxrrpsITqZVHii8VZi8a7acxfaP1zEQBZHT1otDJ9A11WGBivw3pvFrywZOrMnw76jCSYjwfFBXnibgJ3C2jiYo2jYMUejPeFg10OSrI9RItT5H9795xOeamlTMyxt6JISh2xJj3PlZkBOprLhL8n/oX9QA5+9NrSZorWCmJaygaP+g2FlhZ81e+H3YnVwBaK1dNRenQrLtlJY0TC2myDxBxZVJQGIZAo+oxIVtyRn6l7w8HJmvr1fnJwZ2d6XGUAd7u+rUZDBzpZLLbZSR8LGme1Kq7ZlMyt94sHFFYE7UeMfZU7A9Ud/vwS4x4EUSVc9NuI4ZfkooQC57Pc///7vta/98u+rXzZ//ezEm42rnw/e2FVlutsGI/JMNjLdOWonS+OinhOKxnFP/csJUZ/QzRx5Ql6LokiBdSY2MzC9yY/I0y2M69ib/E2N9Sxaj6ck19Jt1gtmR5RXeMHtA/oOeytV6RnQH4ydzbde9bf6OVH9XEmo1w8/aF9J13ZW3txtnFyDlAcbY23SVJVXEvyFHphK9EsPRpCupitypsAkL8/6UrVhNIHrMBLVUJjs5WDC22Qjr7prNqgW/pQcA7dB3uMLOFzrVOtg7wSqQ9PqLcE8Wipq1kuC9WOY3q396MGLQ+/gB29G4vyNRFUW/N6aCvseWAKcHJBilNZioJjHjGfa1lhw3UskYGzAj2KoaSuqgnVcu0uX9YItl+wWhw5EZlXBClsetyBDDd3KYrhiQiouUyTlFmyHD6nAox9jwIK58FCXnSmiK8wbxGKs2nV/1bE0VbYIbqRYmnBZGnRLsdZFNcx8lcfrCqXVRcgaVYc9OFBflZFmuSwfdA4l2Er5UppcIKG7mijNIC0kK+IFfeH5GbzT6msC/7k8s5eFf5ftTCiHD0hic1k6Jo22211QPoTe74MH5K9AvldSCjnBvDqz0X/Zh5KUrhiePJtqtvFEs85Et0zZtDkbBBtu2O37CAiz8LtX4IU1LJPGL1PnCbcVtxAmWbI53ODDTz/VaoM2kQe1hQKgyKv9jGVJksrfrkyUVjkZ3mlFclo99aq0fcdjKyDGcdEktU93ncGz8stQHGhFemgObZrW/Y0XOLe+kM19J7i57UCCbax6xqifWHXIRYxsHoH7IXoKduttHG7Wm+jxkHj7I6Qf2ezhdHHkGfdgtyWrxkCPJRsRtqbSMlUyjSIfPsxYEFR9l+hiieIXBu58tiA+CoxfmBBb1KV7HPn+ExN2H8Iu0awuDLdSl/o/LVjfQ5BPSddJ3iKpUf2fJNRCt2TXt1tb6JlNhDaKEVzyueYZ+mmrZyZwqg7c7mTYMJfwLnWdkXSvOGm5gZ2jv139yQahwPWZaNQS96hn3bP07RZL6jWi1nR4sHO2BGeRPk4GkJVqOeWAZ2rFkzXN/FwJRdElFNRJa7hMYlp1HTm1MWVZlcOPz0UZhPQxTNL17T1EtyUcLpluEIiLQwRe5eNN6NWPfjixyrFMi1I6yoWiGnKKRy2pncY044CZ0Y9BHALiCOLR9JUsArclW1lcZDBNB5+EWSRXjl3N/z6JuSo1GHy7Xe8y816o5a6TNNx7Kcz+B9sIyYi70N8F/y+BCxElYWb2wwKCKA7BsnjFBu+wQSeA64cpfDc38K/rf6/gvt0WHJ/e7S9Yh6J3D8au5K2sahhe8OPrxfw0aNZzFvOG5XJinvQAnUzM894BWvUgI95IXrjXyu9J0gGzSxyrwFqk5P85VBx2U9oAfmOFtyDRMbw8l84zt69I0VW3Uxe/qMrDUS4cSyF/1DKPYWS6SUo2qjTDYZOuE987rAEH+XdC5VAJJ8OArDhUj/oeCEImO1xkmQm+jo4/qDgpzKDMCGF1DOI9UBBYJrT3l2rupTlX6OmuCiys/DoO8iFsuN2lWipGa+4XaSlaXolff716mqZdcM7qSZ9j276Nf1ihnl5MxOo0USRZ2Hppq3ysKFIMbNxo3yOCVA+OVYoFmUg2LdCW5dnCxLtoxPlW0SG9DPNHZC7BHVOog2XiRQgVGOJmWXDADqwrsuEDOxxqymKFwm/ghcAAHPgnf0dFS1v201Qu0GRwH0jsyKV2NaKOtX1XDjwSgo1l1yFQ/jQkmF5GPl5Q2qgZBW0X7kP0CphXtqDijNmWKlWWkQtaHhLhggGQAmlOQoVMM2tgzipEG7fjvKOHI8xchwfgfns7aDvoM9QdVXXq9kQRpOH1kqCpbyK91LX0lMGKYcooJM4w5PqNqgMGjpwz091RQaZzzgoVUax3v336dAZ/Ogw9weuwdakE/paoQ6LhMh8CaAX3KldsMF1R40yYqGGf+BAq3mLxigEmOTSiiXGJbqGJ8SmFtiYf0MMs6ee0qRyMDa9WIFguWvpDFqzGzVB+c5uD13YI7TSHPV1AgAJxYS+0DKhcDvH5VmAVHkI/oJ4+O82gXpPwxU00HoBx0O7TcIf9NI7Y6nXqSD3389WpHLyCpsxRp/JuWRYmpt3wbEubKOFs3bQW3Wgd6xMcU2dDhbrVJVQ4uOaWrg0uWo8dtRyVy7/178NXzAvTLmJ/WlldWvaFabrkjxywZvvWNLbuWLUbDANwgNXzDN0dvXW5ykbYPsfROtpEGZGJXHGClI88T+hkuVCxZDNuaBd04WAslkxX2hBNf6myw17F82TLvmuBObpiVXZxFsYeLQD1USwAKG6qLuQBvvQ8NZcl3x6/gy0UagzxNGk4fgsBbxNn8fKE+pUXvYI1qw+zvT7flW3IGRktrZuetRxOz+4DL7mPgz14JevYO2xfexS0Hi+j2d3Uh3Y3uw4ryUeT8PFQwYoLhDAf67RRwZmRjxBfatzEsVp8Z7WIjZVmgGfDS4jLwXgaTGFYC0cH+47YSys8OYeS9G5JIDsrThvYuIhuycp+ojqKaQkupSiEY8/JjIUrpKZcFKRdUTIfQc0RHDHnin0wcsEFM9yFCXJmu67wLk20hfx2C77tpUs9oajaEHjbSwUvvk49c/nBBHPUmSfk14uijQU9sMKBL4e8XofWuvSbJ4lDapnYue589WAdo78qzcWVD8pOSR9Gc1VWBWcm1BoXLQGn74B+1pvR2N1oxMTvbALvF+9jujtf3//lfr7ynp7enRvTjBKZE+1bTHREFUVHrOmsNj4OAu3xW16J/x8s3oBMcAYBhpJgDd2Bf71Mc22E/EGLWiLDYix3Y6DogqsapetaLDKZfGsyeylTEuq7w9QS9k5mU2ih4YwxQgsc24jFmWgmOOvrfgsPAfByQ38NqBLW1rKMdmYuD97Dep9sIQwO+Af8/fsmfzjzqjfHTVSMSDN2H/dI/KYHd3qqiM1hGi4tV46nOqD9sXdyRoGKSVLgrlWWpfwOdNljHKKa74dsXXEtN7IP4NfHuwAC/KV36CBsQsDNqKojOQYQ6k0JYZX49yCOsNYID5vQz8rJs3MThA+nADNrg0rJL2RMhtfXbcPCQJrT1rlVERIt19YBmpi7jw5hBQCRxMrOpuH2ZMagKYKnntAYFK4LfsYh+6jmZzZ2wWJ8GUBt/RqialhV3uhVLjTHGArM17XLuTkTl9h2sHKZyV9cvcpwaJAVlTEnt1lNoQO4Cb3tIUqAldq/q/GHsDdlCb5/d4gttgLbU7dGRnXhS0niS8mQX38O6GneSlbfYzSljrqLc9bmprZ+XIi4MdTWZF6j7RoXLlXnUe4FNm3mki0g41y37sKjDmT79Jykwb5syVdg5wiakWThvCr9VnR37GLkamnI6W35r1uVb3Qm8GXywD3pODNxos/GqT+MclFKPNowkUVAMgpsjPLE9LwzwIRJBTIUqmhzIx0GeMtSgcqaSmZlWQiUPnVXqFWkXL+5pGakl9ZSjN7Lr+QITtmt4we+0Cm7cUzDhGfgztFFBql/BWMHHV01MotE2lVTVdz6TFAfzdyepV01R+Cq6eY4vlrFT7NE5tyrQLnTpuoHk12K+nm9M8KuG/7NidXXaNh1sivinnpFquwssq+nq49XUr6+aC7covN+aHIX3qZrf7859aqN8PZPXbRF23IvBM8Rvt0eeI76NBWiEpbMeGaKwYx5mxjOsYrYsOG9zmH3RSWCtLVdv5DmbEzSyYxPlzU+NYHxOWGpb8XC8CKcrPz2eN+06q9sDe3xllB2vfi+YrJe+0AEbPCa12tElpNdLx7QkKzX3UYEZfqK10tzLsyTLxg/85Qs2CFI3xaMXjAcqj/hcvGxk2K50uPbctHLperGqdcLh+SYYT84jhvsg3gbHHxwp9Wd992LNyiJcz8sTuuEQYDOPbwkBdMrHyPv3Zp53rF53oT0xLeielax8boPD6XaNqvpsnOFrfra1YbjhyrxI1Irq8pqkFtj5FCYJ2jj3U1TBTYfycoN7dTl5Cpbhzqqaydo48RUtYGUUMz+FUlfPwJyLNploTzlzFwu/G9BvPcOh8tsz2W038MiU1jdTKYCly4sfa9t4MXFjd6BbwNePFcjO7gKSXGXn9Hm92hr893ElyafSVl4NtL6cJMcUcBreY2P+AQPAH/tj8FmiILw3upsFLWUj86+2gW36Shaqq3ugY0bDCwEDq8Nr4k41WGzk4s1ycKg3jpNG6cOvSD4O8Avu2BEbVRxK35CKt3uivs6iz5cDu6vMpNeR3CvWbWp6qRxS7ApjqKUplTwIu8+RBtIhNf/Hw==&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <rect x="1420" y="340" width="160" height="330" rx="24" ry="24" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 158px; height: 1px; padding-top: 347px; margin-left: 1421px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <div>
+                                    /perception/traffic_light_recognition/
+                                    <br/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1500" y="359" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    /perception/traffic_light_...
+                </text>
+            </switch>
+        </g>
+        <rect x="830" y="1370" width="200" height="260" rx="30" ry="30" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 198px; height: 1px; padding-top: 1377px; margin-left: 831px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <div>
+                                    /perception/occupancy_grid_map/
+                                    <br/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="930" y="1389" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    /perception/occupancy_grid_map/
+                </text>
+            </switch>
+        </g>
+        <rect x="1050" y="1200" width="230" height="430" rx="34.5" ry="34.5" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 228px; height: 1px; padding-top: 1207px; margin-left: 1051px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <div>
+                                    /perception/obstacle_segmentation/
+                                    <br/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1165" y="1219" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    /perception/obstacle_segmentation/
+                </text>
+            </switch>
+        </g>
+        <rect x="790" y="130" width="550" height="932.5" rx="82.5" ry="82.5" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 548px; height: 1px; padding-top: 137px; margin-left: 791px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <div>
+                                    /perception/object_recognition/
+                                    <br/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1065" y="149" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    /perception/object_recognition/
+                </text>
+            </switch>
+        </g>
+        <rect x="985" y="170" width="320" height="550" rx="48" ry="48" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 318px; height: 1px; padding-top: 177px; margin-left: 986px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <div>
+                                    /perception/object_recognition/detection/euclidean/
+                                    <br/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1145" y="189" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    /perception/object_recognition/detection/euclidean/
+                </text>
+            </switch>
+        </g>
+        <rect x="2330" y="180" width="570" height="370" rx="55.5" ry="55.5" fill="#ffe6cc" stroke="#d79b00" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 568px; height: 1px; padding-top: 187px; margin-left: 2331px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                trajectory_follower
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2615" y="199" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    trajectory_follower
+                </text>
+            </switch>
+        </g>
+        <rect x="2390" y="1610" width="120" height="60" rx="9" ry="9" fill="#647687" stroke="#314354" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2391px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Planning
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2450" y="1644" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Planning
+                </text>
+            </switch>
+        </g>
+        <rect x="2543" y="1610" width="120" height="60" rx="9" ry="9" fill="#647687" stroke="#314354" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2544px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Control
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2603" y="1644" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Control
+                </text>
+            </switch>
+        </g>
+        <rect x="2237" y="1610" width="120" height="60" rx="9" ry="9" fill="#647687" stroke="#314354" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2238px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Perception
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2297" y="1644" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Perception
+                </text>
+            </switch>
+        </g>
+        <rect x="2983" y="1610" width="120" height="60" rx="9" ry="9" fill="#647687" stroke="#314354" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2984px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Vehicle
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3043" y="1644" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Vehicle
+                </text>
+            </switch>
+        </g>
+        <rect x="1930" y="1610" width="120" height="60" rx="9" ry="9" fill="#647687" stroke="#314354" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 1931px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Sensing
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1990" y="1644" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Sensing
+                </text>
+            </switch>
+        </g>
+        <rect x="2840" y="1610" width="120" height="60" rx="9" ry="9" fill="#647687" stroke="#314354" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2841px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                VehicleInterface
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2900" y="1644" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    VehicleInterface
+                </text>
+            </switch>
+        </g>
+        <rect x="2083" y="1610" width="120" height="60" rx="9" ry="9" fill="#647687" stroke="#314354" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2084px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Localization
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2143" y="1644" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Localization
+                </text>
+            </switch>
+        </g>
+        <rect x="2690" y="1610" width="120" height="60" rx="9" ry="9" fill="#647687" stroke="#314354" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2691px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                System
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2750" y="1644" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    System
+                </text>
+            </switch>
+        </g>
+        <path d="M 3419 1049 L 3324.5 1049 L 3236.37 1049.47" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 3231.12 1049.49 L 3238.1 1045.96 L 3236.37 1049.47 L 3238.14 1052.96 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1049px; margin-left: 3354px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /diagnostics
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3354" y="1052" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /diagnostics
+                </text>
+            </switch>
+        </g>
+        <rect x="1932.5" y="1730" width="120" height="60" rx="9" ry="9" fill="#647687" stroke="#314354" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1760px; margin-left: 1934px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                XX1
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1993" y="1764" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    XX1
+                </text>
+            </switch>
+        </g>
+        <rect x="2081.25" y="1730" width="120" height="60" rx="9" ry="9" fill="#647687" stroke="#314354" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1760px; margin-left: 2082px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                X2
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2141" y="1764" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    X2
+                </text>
+            </switch>
+        </g>
+        <rect x="2232.5" y="1730" width="120" height="60" rx="9" ry="9" fill="#647687" stroke="#314354" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1760px; margin-left: 2234px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                X1
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2293" y="1764" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    X1
+                </text>
+            </switch>
+        </g>
+        <rect x="2372.5" y="1730" width="120" height="60" rx="9" ry="9" fill="#647687" stroke="#314354" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1760px; margin-left: 2374px;">
+                        <div data-drawio-colors="color: #ffffff; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(255, 255, 255); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                S1
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2433" y="1764" fill="#ffffff" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    S1
+                </text>
+            </switch>
+        </g>
+        <path d="M 60 1276.37 L 60 1510" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 60 1271.12 L 63.5 1278.12 L 60 1276.37 L 56.5 1278.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1390px; margin-left: 60px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /initialpose
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="60" y="1393" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /initialpose
+                </text>
+            </switch>
+        </g>
+        <path d="M 680 1123.63 L 680 1050" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 680 1128.88 L 676.5 1121.88 L 680 1123.63 L 683.5 1121.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1090px; margin-left: 680px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /vehicle/status/velocity_report
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="680" y="1093" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /vehicle/status/velocity_report
+                </text>
+            </switch>
+        </g>
+        <path d="M 120 1240 L 200 1240 L 200 1420 L 280 1420" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" stroke-dasharray="3 3" pointer-events="stroke"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1330px; margin-left: 200px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                &lt;pose_initializer_srv&gt;
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="200" y="1333" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    &lt;pose_initializer_srv&gt;
+                </text>
+            </switch>
+        </g>
+        <path d="M 3036.37 735 L 3440 735" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 3031.12 735 L 3038.12 731.5 L 3036.37 735 L 3038.12 738.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 720px; margin-left: 3280px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                <div style="text-align: left">
+                                    /autoware/engage [Engage]
+                                </div>
+                                <div style="text-align: left">
+                                    /current_gate_mode [GateMode]
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3280" y="723" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /autoware/engage [Engage]...
+                </text>
+            </switch>
+        </g>
+        <rect x="2070" y="240" width="80" height="20" fill="none" stroke="none" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 78px; height: 1px; padding-top: 250px; margin-left: 2071px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                &lt;Parking&gt;
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2110" y="254" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    &lt;Parking&gt;
+                </text>
+            </switch>
+        </g>
+        <path d="M 609.37 1230 L 680 1230 L 680 1170" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 604.12 1230 L 611.12 1226.5 L 609.37 1230 L 611.12 1233.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1202px; margin-left: 680px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                vehicle_velocity_converter/
+                                <br/>
+                                twist_with_covariance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="680" y="1205" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    vehicle_velocity_converter/...
+                </text>
+            </switch>
+        </g>
+        <path d="M 1870 501 L 1870 520 L 2140 520 L 2140 735 L 2343.63 735" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2348.88 735 L 2341.88 738.5 L 2343.63 735 L 2341.88 731.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 664px; margin-left: 2002px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                /planning/turn_indicators_cmd [TurnIndicatorsCommand]
+                                <br/>
+                                /planning/hazard_lights_cmd [HazardLightsCommand]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2002" y="667" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px">
+                    /...
+                </text>
+            </switch>
+        </g>
+        <path d="M 1450 1650 L 1450 1456.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1450 1451.12 L 1453.5 1458.12 L 1450 1456.37 L 1446.5 1458.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1560px; margin-left: 1450px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /planning/scenario_planning/max_velocity_candidates
+                                <br/>
+                                [tier4_planning_msgs/msg/VelocityLimit]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1450" y="1563" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /planning/scenario_planning/max_velocity_candidates...
+                </text>
+            </switch>
+        </g>
+        <path d="M 2020 340 L 2020 1290 L 1892.5 1290 L 1892.5 1313.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1892.5 1318.88 L 1889 1311.88 L 1892.5 1313.63 L 1896 1311.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1260px; margin-left: 2020px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                <span style="color: rgb(0 , 0 , 0) ; font-family: &quot;helvetica&quot; ; font-size: 11px ; font-style: normal ; font-weight: 400 ; letter-spacing: normal ; text-align: center ; text-indent: 0px ; text-transform: none ; word-spacing: 0px ; background-color: rgb(255 , 255 , 255) ; display: inline ; float: none">
+                                    parking/trajectory [Trajectory]
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2020" y="1263" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    parking/trajectory [Trajectory]
+                </text>
+            </switch>
+        </g>
+        <path d="M 2726 1167 L 2726 1323.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2726 1328.88 L 2722.5 1321.88 L 2726 1323.63 L 2729.5 1321.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="0" y="1510" width="120" height="40" rx="6" ry="6" fill="#bac8d3" stroke="#23445d" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1530px; margin-left: 1px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                HMI
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="60" y="1534" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    HMI
+                </text>
+            </switch>
+        </g>
+        <rect x="1390" y="1650" width="120" height="40" rx="6" ry="6" fill="#bac8d3" stroke="#23445d" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1670px; margin-left: 1391px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                HMI
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1450" y="1674" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    HMI
+                </text>
+            </switch>
+        </g>
+        <rect x="1761" y="0" width="120" height="40" rx="6" ry="6" fill="#bac8d3" stroke="#23445d" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 20px; margin-left: 1762px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                HMI
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1821" y="24" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    HMI
+                </text>
+            </switch>
+        </g>
+        <rect x="3440" y="715" width="120" height="40" rx="6" ry="6" fill="#bac8d3" stroke="#23445d" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 735px; margin-left: 3441px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                HMI
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3500" y="739" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    HMI
+                </text>
+            </switch>
+        </g>
+        <path d="M 3190 60 L 3190 243.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 3190 248.88 L 3186.5 241.88 L 3190 243.63 L 3193.5 241.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 133px; margin-left: 3192px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                <span style="text-align: left">
+                                    /api/external/set/command/remote/control: [tier4_external_api_msgs/msg/ControlCommandStamped]
+                                </span>
+                                <br style="text-align: left"/>
+                                <span style="text-align: left">
+                                    /api/external/set/command/remote/heartbeat: [tier4_external_api_msgs/msg/Heartbeat]
+                                </span>
+                                <br style="text-align: left"/>
+                                <span style="text-align: left">
+                                    /api/external/set/command/remote/shift: [tier4_external_api_msgs/msg/GearShiftStamped]
+                                </span>
+                                <br style="text-align: left"/>
+                                <span style="text-align: left">
+                                    /api/external/set/command/remote/turn_signal: [tier4_external_api_msgs/msg/TurnSignalStamped]
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3192" y="136" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /...
+                </text>
+            </switch>
+        </g>
+        <rect x="3130" y="20" width="120" height="40" rx="6" ry="6" fill="#bac8d3" stroke="#23445d" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 40px; margin-left: 3131px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                HMI
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3190" y="44" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    HMI
+                </text>
+            </switch>
+        </g>
+        <path d="M 2635 490 L 2635 581.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2635 586.88 L 2631.5 579.88 L 2635 581.63 L 2638.5 579.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="2357" y="870" width="140" height="40" rx="6" ry="6" fill="#b0e3e6" stroke="#0e8088" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 138px; height: 1px; padding-top: 890px; margin-left: 2358px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                accel_map_calibrator
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2427" y="894" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    accel_map_calibrator
+                </text>
+            </switch>
+        </g>
+        <path d="M 2595.48 764.82 L 2595.5 840 L 2427 840 L 2427 863.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2427 868.88 L 2423.5 861.88 L 2427 863.63 L 2430.5 861.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 2595 910 L 2595 970 L 2515 970 L 2515 890 L 2503.37 890" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2498.12 890 L 2505.12 886.5 L 2503.37 890 L 2505.12 893.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 3130 270 L 2936 270 L 2936.16 699.29" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2936.16 704.54 L 2932.66 697.54 L 2936.16 699.29 L 2939.66 697.54 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 600px; margin-left: 2953px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: #FFFFFF; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                <div style="text-align: left">
+                                    <font style="font-size: 11px">
+                                        /api/external/set/command/remote/control
+                                        <br/>
+                                    </font>
+                                </div>
+                                <div style="text-align: left">
+                                    <font style="font-size: 11px">
+                                        [tier4_external_api_msgs/msg/ControlCommandStamped]
+                                    </font>
+                                </div>
+                                <div style="text-align: left">
+                                    <font style="font-size: 11px">
+                                        /api/external/set/command/remote/shift
+                                    </font>
+                                </div>
+                                <div style="text-align: left">
+                                    <font style="font-size: 11px">
+                                        [tier4_external_api_msgs/msg/GearShiftStamped]
+                                    </font>
+                                </div>
+                                <div style="text-align: left">
+                                    <font style="font-size: 11px">
+                                        /api/external/set/command/remote/turn_signal
+                                    </font>
+                                </div>
+                                <div style="text-align: left">
+                                    <font style="font-size: 11px">
+                                        [tier4_external_api_msgs/msg/TurnSignalStamped]
+                                    </font>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2953" y="604" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /...
+                </text>
+            </switch>
+        </g>
+        <path d="M 3190 400 L 3190 660 L 2993.5 660 L 2993.31 698.51" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2993.29 703.76 L 2989.82 696.74 L 2993.31 698.51 L 2996.82 696.78 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 443px; margin-left: 3213px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                <div style="text-align: left">
+                                    /api/external/get/command/selected/control
+                                </div>
+                                [tier4_external_api_msgs/msg/ControlCommandStamped]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3213" y="446" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /...
+                </text>
+            </switch>
+        </g>
+        <path d="M 2650 1470 L 2650 1420 L 2569 1420 L 2569 1376.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2569 1371.12 L 2572.5 1378.12 L 2569 1376.37 L 2565.5 1378.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 2650 1470 L 2650 1420 L 2726 1420 L 2726 1376.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2726 1371.12 L 2729.5 1378.12 L 2726 1376.37 L 2722.5 1378.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1440px; margin-left: 2650px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /vehicle/engage
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2650" y="1443" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /vehicle/engage
+                </text>
+            </switch>
+        </g>
+        <rect x="2590" y="1470" width="120" height="40" rx="6" ry="6" fill="#bac8d3" stroke="#23445d" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1490px; margin-left: 2591px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                HMI
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2650" y="1494" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    HMI
+                </text>
+            </switch>
+        </g>
+        <path d="M 1821 120 L 1821 190 L 2270 190 L 2270 490 L 2363.63 490" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2368.88 490 L 2361.88 493.5 L 2363.63 490 L 2361.88 486.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <rect x="1020" y="210" width="250" height="310" rx="37.5" ry="37.5" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 248px; height: 1px; padding-top: 217px; margin-left: 1021px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                <div>
+                                    <span>
+                                        /perception/
+                                    </span>
+                                    <span>
+                                        object_recognition/
+                                    </span>
+                                    <span>
+                                        detection/
+                                    </span>
+                                </div>
+                                <div>
+                                    <span>
+                                        euclidean/clustering/
+                                    </span>
+                                    <br/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1145" y="229" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    /perception/object_recognition/detection/...
+                </text>
+            </switch>
+        </g>
+        <path d="M 1140 310 L 1140 363.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1140 368.88 L 1136.5 361.88 L 1140 363.63 L 1143.5 361.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 340px; margin-left: 1140px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                euclidean/clustering/downsampled/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1140" y="343" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    euclidean/clustering/downsampled/pointcloud
+                </text>
+            </switch>
+        </g>
+        <rect x="1080" y="270" width="120" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 290px; margin-left: 1081px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                voxel_grid_filter
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1140" y="294" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    voxel_grid_filter
+                </text>
+            </switch>
+        </g>
+        <path d="M 1140 410 L 1140 453.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1140 458.88 L 1136.5 451.88 L 1140 453.63 L 1143.5 451.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 435px; margin-left: 1140px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                euclidean/clustering/outlier_filter/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1140" y="438" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    euclidean/clustering/outlier_filter/pointcloud
+                </text>
+            </switch>
+        </g>
+        <rect x="1080" y="370" width="120" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 390px; margin-left: 1081px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                outlier_filter
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1140" y="394" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    outlier_filter
+                </text>
+            </switch>
+        </g>
+        <path d="M 1140 500 L 1140 533.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1140 538.88 L 1136.5 531.88 L 1140 533.63 L 1143.5 531.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 510px; margin-left: 1140px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                /lidar/cluster
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1140" y="513" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /lidar/cluster
+                </text>
+            </switch>
+        </g>
+        <rect x="1080" y="460" width="120" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 480px; margin-left: 1081px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                euclidean_cluster
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1140" y="484" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    euclidean_cluster
+                </text>
+            </switch>
+        </g>
+        <path d="M 1140 80 L 1140 263.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1140 268.88 L 1136.5 261.88 L 1140 263.63 L 1143.5 261.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 100px; margin-left: 1140px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                /perception/obstacle_segmentation/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1140" y="103" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /perceptio...
+                </text>
+            </switch>
+        </g>
+        <path d="M 905 520 L 905 620 L 1063.63 620" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1068.88 620 L 1061.88 623.5 L 1063.63 620 L 1061.88 616.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 560px; margin-left: 905px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                /rois*
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="905" y="563" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /rois*
+                </text>
+            </switch>
+        </g>
+        <path d="M 907 876.5 L 907 812.5 L 987.63 812.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 992.88 812.5 L 985.88 816 L 987.63 812.5 L 985.88 809 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 832px; margin-left: 907px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                detection_by_tracker/objects
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="907" y="835" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    detection_by_tracker/objects
+                </text>
+            </switch>
+        </g>
+        <rect x="847" y="876.5" width="120" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 897px; margin-left: 848px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                detection_by_
+                                <br/>
+                                tracker_node
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="907" y="900" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    detection_by_...
+                </text>
+            </switch>
+        </g>
+        <path d="M 1049 916.5 L 1049 962.5 L 907 962.5 L 907 922.87" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 907 917.62 L 910.5 924.62 L 907 922.87 L 903.5 924.62 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 1160 1290 L 1160 1320 L 800 1320 L 800 1500 L 863.63 1499.97" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 868.88 1499.97 L 861.88 1503.47 L 863.63 1499.97 L 861.88 1496.47 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 1160 1385 L 1160 1440 L 996.37 1439.97" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 991.12 1439.97 L 998.12 1436.47 L 996.37 1439.97 L 998.12 1443.47 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 1160 1385 L 1160 1500 L 996.37 1499.97" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 991.12 1499.97 L 998.12 1496.47 L 996.37 1499.97 L 998.12 1503.47 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 1160 1385 L 1160 1543.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1160 1548.88 L 1156.5 1541.88 L 1160 1543.63 L 1163.5 1541.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1400px; margin-left: 1160px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                no_ground/oneshot/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1160" y="1403" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    no_ground/oneshot/pointcloud
+                </text>
+            </switch>
+        </g>
+        <path d="M 1160 1290 L 1160 1338.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1160 1343.88 L 1156.5 1336.88 L 1160 1338.63 L 1163.5 1336.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1310px; margin-left: 1160px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                range_cropped/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1160" y="1313" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    range_cropped/pointcloud
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/blob/develop/sensing/preprocessor/pointcloud/pointcloud_preprocessor/docs/ScanGroundFilter.md">
+            <rect x="1100" y="1345" width="120" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1365px; margin-left: 1101px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    common_
+                                    <br/>
+                                    ground_filter
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1160" y="1369" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        common_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 930 1459.97 L 930 1480 L 930 1460 L 930 1473.6" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 930 1478.85 L 926.5 1471.85 L 930 1473.6 L 933.5 1471.85 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <a xlink:href="https://github.com/tier4/pointcloud_to_laserscan">
+            <rect x="870" y="1419.97" width="120" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1440px; margin-left: 871px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    pointcloud_to_
+                                    <br/>
+                                    laserscan
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="930" y="1444" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        pointcloud_to_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 930 1519.97 L 930 1570 L 1083.63 1570" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1088.88 1570 L 1081.88 1573.5 L 1083.63 1570 L 1081.88 1566.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1552px; margin-left: 934px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                occupancy_grid
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="934" y="1556" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    o...
+                </text>
+            </switch>
+        </g>
+        <path d="M 930 1519.97 L 930.23 1703.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 930.25 1708.88 L 926.73 1701.89 L 930.23 1703.63 L 933.73 1701.87 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1669px; margin-left: 930px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                /perception/occupancy_grid_map/map
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="930" y="1673" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /perception/occupancy_grid_map/map
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/develop/sensing/preprocessor/pointcloud/laserscan_to_occupancy_grid_map">
+            <rect x="870" y="1479.97" width="120" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1500px; margin-left: 871px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    laserscan_to_
+                                    <br/>
+                                    occupancy_grid_map
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="930" y="1504" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        laserscan_to_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <a xlink:href="https://github.com/tier4/autoware.iv/blob/develop/sensing/preprocessor/pointcloud/pointcloud_preprocessor/docs/OccupancyGridMapOutlierFilter.md">
+            <rect x="1090" y="1550" width="140" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 138px; height: 1px; padding-top: 1570px; margin-left: 1091px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    occupancy_grid_
+                                    <br/>
+                                    map_based_outlier_filter
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1160" y="1574" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        occupancy_grid_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 1160 1590 L 1160 1703.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1160 1708.88 L 1156.5 1701.88 L 1160 1703.63 L 1163.5 1701.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1670px; margin-left: 1160px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                /perception/obstacle_segmentation/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1160" y="1673" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /perception/obstacle_segmentation/pointcloud
+                </text>
+            </switch>
+        </g>
+        <rect x="1100" y="1250" width="120" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1270px; margin-left: 1101px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                crop_box_filter
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1160" y="1274" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    crop_box_filter
+                </text>
+            </switch>
+        </g>
+        <path d="M 1160 1140 L 1160 1243.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1160 1248.88 L 1156.5 1241.88 L 1160 1243.63 L 1163.5 1241.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1180px; margin-left: 1160px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                /concatenated/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1160" y="1183" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /concatena...
+                </text>
+            </switch>
+        </g>
+        <path d="M 1500 520 L 1500 563.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1500 568.88 L 1496.5 561.88 L 1500 563.63 L 1503.5 561.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 3170 1420 L 3170 1489.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 3170 1494.88 L 3166.5 1487.88 L 3170 1489.63 L 3173.5 1487.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1460px; margin-left: 3170px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                /autoware/state
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3170" y="1463" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /autoware/state
+                </text>
+            </switch>
+        </g>
+        <path d="M 3110 1400 L 3080 1400 L 3080 1489.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 3080 1494.88 L 3076.5 1487.88 L 3080 1489.63 L 3083.5 1487.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1455px; margin-left: 3070px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                /autoware/engage
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3070" y="1458" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /autoware/engage
+                </text>
+            </switch>
+        </g>
+        <path d="M 3230 1400 L 3270 1400 L 3270 1489.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 3270 1494.88 L 3266.5 1487.88 L 3270 1489.63 L 3273.5 1487.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1460px; margin-left: 3273px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /diagnostics
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3273" y="1464" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /...
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/system/autoware_state_monitor">
+            <rect x="3110" y="1380" width="120" height="40" rx="6" ry="6" fill="#f8cecc" stroke="#b85450" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1400px; margin-left: 3111px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    ad_service_
+                                    <br/>
+                                    state_monitor
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="3170" y="1404" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        ad_service_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 3320 1180 L 3320 1100 L 3236.37 1100" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 3231.12 1100 L 3238.12 1096.5 L 3236.37 1100 L 3238.12 1103.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1150px; margin-left: 3320px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                <div style="text-align: left">
+                                    <span>
+                                        /control/current_gate_mode
+                                    </span>
+                                </div>
+                                <div style="text-align: left">
+                                    <span>
+                                        /vehicle/status/control_mode
+                                    </span>
+                                </div>
+                                <div style="text-align: left">
+                                    <span>
+                                        /autoware/state
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3320" y="1153" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /control/c...
+                </text>
+            </switch>
+        </g>
+        <path d="M 3170 1117 L 3170 1173.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 3170 1178.88 L 3166.5 1171.88 L 3170 1173.63 L 3173.5 1171.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1147px; margin-left: 3170px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                /diagnostics_err
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3170" y="1150" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /diagnostics_err
+                </text>
+            </switch>
+        </g>
+        <path d="M 3540 1320 L 3170 1320 L 3170 1373.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 3170 1378.88 L 3166.5 1371.88 L 3170 1373.63 L 3173.5 1371.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1350px; margin-left: 3390px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                /control/command/control_cmd
+                                <br/>
+                                /control/trajectory_follower/control_cmd
+                                <br/>
+                                /initialpose2d
+                                <br/>
+                                /localization/kinematic_state
+                                <br/>
+                                /map/pointcloud_map
+                                <br/>
+                                /map/vector_map
+                                <br/>
+                                /perception/object_recognition/objects
+                                <br/>
+                                /planning/mission_planning/route
+                                <br/>
+                                /planning/scenario_planning/trajectory
+                                <br/>
+                                /system/emergency/control_cmd
+                                <br/>
+                                /vehicle/status/control_mode
+                                <br/>
+                                /vehicle/status/steering_status
+                                <br/>
+                                /vehicle/status/velocity_status
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3390" y="1353" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /contr...
+                </text>
+            </switch>
+        </g>
+        <rect x="2543" y="1610" width="120" height="60" rx="9" ry="9" fill="#ffe6cc" stroke="#d79b00" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2544px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Control
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2603" y="1644" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Control
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/control/latlon_muxer">
+            <rect x="2575" y="450" width="120" height="40" rx="6" ry="6" fill="#ffe6cc" stroke="#d79b00" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 470px; margin-left: 2576px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    latlon_muxer
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="2635" y="474" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        latlon_muxer
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 2591 310 L 2591 430 L 2635 430 L 2635 443.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2635 448.88 L 2631.5 441.88 L 2635 443.63 L 2638.5 441.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 350px; margin-left: 2610px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                <div>
+                                    /control/trajectory_follower/lateral/control_cmd
+                                </div>
+                                <div>
+                                    [AckermannLateralControlCommand]
+                                </div>
+                                <div>
+                                    <br/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2610" y="353" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /control/trajectory_follower/lateral/control_cmd...
+                </text>
+            </switch>
+        </g>
+        <path d="M 2790 310 L 2790 430 L 2635 430 L 2635 443.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2635 448.88 L 2631.5 441.88 L 2635 443.63 L 2638.5 441.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 380px; margin-left: 2768px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                /control/trajectory_follower/longitudinal/control_cmd
+                                <br/>
+                                [LongitudinalControlCommand]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2768" y="383" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /control/trajectory_follower/longitudinal/control_cmd...
+                </text>
+            </switch>
+        </g>
+        <path d="M 2635 490 L 2635 570 L 2507 570 L 2507.08 698.21" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2507.08 703.46 L 2503.58 696.46 L 2507.08 698.21 L 2510.58 696.46 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 520px; margin-left: 2635px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                <div>
+                                    /control/trajectory_follower/control_cmd
+                                </div>
+                                <div>
+                                    [AckermannControlCommand]
+                                </div>
+                                <div>
+                                    <br/>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2635" y="523" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /control/trajectory_follower/control_cmd...
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/control/mpc_follower">
+            <rect x="2531" y="270" width="120" height="40" rx="6" ry="6" fill="#ffe6cc" stroke="#d79b00" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 290px; margin-left: 2532px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    lateral_controller
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="2591" y="294" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        lateral_controller
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/control/velocity_controller">
+            <rect x="2710" y="270" width="160" height="40" rx="6" ry="6" fill="#ffe6cc" stroke="#d79b00" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 158px; height: 1px; padding-top: 290px; margin-left: 2711px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    longitudinal_controller
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="2790" y="294" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        longitudinal_controller
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/control/vehicle_cmd_gate">
+            <rect x="2350" y="705" width="680" height="60" rx="9" ry="9" fill="#ffe6cc" stroke="#d79b00" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 678px; height: 1px; padding-top: 735px; margin-left: 2351px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    vehicle_cmd_gate
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="2690" y="739" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        vehicle_cmd_gate
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 2596.08 765.66 L 2595.07 863.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2595.01 868.88 L 2591.58 861.85 L 2595.07 863.63 L 2598.58 861.92 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 813px; margin-left: 2603px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                control/command/control_cmd
+                                <br/>
+                                [AckermannControlCommand]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2603" y="816" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    c...
+                </text>
+            </switch>
+        </g>
+        <path d="M 2635 628 L 2635 660 L 2634.93 698.33" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2634.92 703.58 L 2631.43 696.58 L 2634.93 698.33 L 2638.43 696.59 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 658px; margin-left: 2635px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /control/shift_decider/gear_cmd
+                                <br/>
+                                [GearCommand]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2635" y="661" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /control/shift_decider/gear_cmd...
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/control/shift_decider">
+            <rect x="2575" y="588" width="120" height="40" rx="6" ry="6" fill="#ffe6cc" stroke="#d79b00" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 608px; margin-left: 2576px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    shift_decider
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="2635" y="612" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        shift_decider
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/vehicle/remote_cmd_converter">
+            <rect x="3130" y="360" width="120" height="40" rx="6" ry="6" fill="#ffe6cc" stroke="#d79b00" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 380px; margin-left: 3131px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    external_cmd_
+                                    <br/>
+                                    converter
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="3190" y="384" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        external_cmd_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 2591 230 L 2591 263.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2591 268.88 L 2587.5 261.88 L 2591 263.63 L 2594.5 261.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 2430 510 L 2430 623.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2430 628.88 L 2426.5 621.88 L 2430 623.63 L 2433.5 621.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 570px; margin-left: 2430px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /diagnostics
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2430" y="573" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /diagnostics
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/control/trajectory_follower/lane_departure_checker">
+            <rect x="2370" y="470" width="120" height="40" rx="6" ry="6" fill="#ffe6cc" stroke="#d79b00" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 490px; margin-left: 2371px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    lane_departure_
+                                    <br/>
+                                    checker
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="2430" y="494" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        lane_departure_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 2531 290 L 2430 290 L 2430 463.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2430 468.88 L 2426.5 461.88 L 2430 463.63 L 2433.5 461.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 409px; margin-left: 2430px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: nowrap;">
+                                predicted_trajectory
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2430" y="412" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    predicted_trajectory
+                </text>
+            </switch>
+        </g>
+        <path d="M 3190 290 L 3190 353.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 3190 358.88 L 3186.5 351.88 L 3190 353.63 L 3193.5 351.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 325px; margin-left: 3190px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /external/selected/external_control_cmd
+                                <br/>
+                                [tier4_external_api_msgs/msg/ControlCommandStamped]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3190" y="328" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /external/selected/external_control_cmd...
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/control/external_cmd_selector">
+            <rect x="3130" y="250" width="120" height="40" rx="6" ry="6" fill="#ffe6cc" stroke="#d79b00" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 270px; margin-left: 3131px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    external_cmd_
+                                    <br/>
+                                    selector
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="3190" y="274" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        external_cmd_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 2827.83 765 L 2825.96 1102.65" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2825.93 1107.9 L 2822.47 1100.88 L 2825.96 1102.65 L 2829.47 1100.92 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 870px; margin-left: 2774px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /current_gate_mode [GateMode]
+                                <div>
+                                    /gear_cmd [GearCommand]
+                                </div>
+                                <div>
+                                    /turn_indicators_cmd  [TurnIndicatorCommand]
+                                </div>
+                                <div>
+                                    <div>
+                                        /hazard_lights_cmd  [HazardLightsCommand]
+                                    </div>
+                                </div>
+                                <div>
+                                    /vehicle_emergency_cmd [VehicleEmergencyStamped]
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2774" y="873" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px">
+                    /current_gate_mode [GateMode]...
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/planning/scenario_planning/lane_driving/behavior_planning/behavior_velocity_planner">
+            <rect x="1720" y="570" width="200" height="390" rx="30" ry="30" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 198px; height: 1px; padding-top: 577px; margin-left: 1721px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    behavior_velocity_planner
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1820" y="589" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        behavior_velocity_planner
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <rect x="2390" y="1610" width="120" height="60" rx="9" ry="9" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2391px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                Planning
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2450" y="1644" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Planning
+                </text>
+            </switch>
+        </g>
+        <path d="M 1862.5 1450 L 1862.5 1510 L 2300 1510 L 2300 738 C 2303.9 738 2303.9 732 2300 732 L 2300 732 L 2300 493 C 2303.9 493 2303.9 487 2300 487 L 2300 487 L 2300 230 L 2790 230 L 2790 263.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 2790 268.88 L 2786.5 261.88 L 2790 263.63 L 2793.5 261.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1481px; margin-left: 1863px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /planning/scenario_planning/trajectory [Trajectory]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1863" y="1484" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /planning/scenario_planning/trajectory [Trajectory]
+                </text>
+            </switch>
+        </g>
+        <path d="M 1821 120 L 1821 190 L 1650 190 L 1650 1340 L 1796.13 1340" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1801.38 1340 L 1794.38 1343.5 L 1796.13 1340 L 1794.38 1336.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <path d="M 1820 1080 L 1820 1113.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1820 1118.88 L 1816.5 1111.88 L 1820 1113.63 L 1823.5 1111.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1090px; margin-left: 1821px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                motion_planning/obstacle_avoidance_planner/trajectory [Trajectory]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1821" y="1093" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    motion_planning/obstacle_avoidance_planner/trajectory [Trajectory]
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/planning/scenario_planning/lane_driving/motion_planning/obstacle_avoidance_planner">
+            <rect x="1760" y="1040" width="120" height="40" rx="6" ry="6" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1060px; margin-left: 1761px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    obstacle_
+                                    <br/>
+                                    avoidance_planner
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1820" y="1064" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        obstacle_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 1820 1160 L 1820 1193.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1820 1198.88 L 1816.5 1191.88 L 1820 1193.63 L 1823.5 1191.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1180px; margin-left: 1820px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                motion_planning/surround_obstacle_checker/trajectory [Trajectory]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="1183" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    motion_planning/surround_obstacle_checker/trajectory [Trajectory]
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/planning/scenario_planning/lane_driving/motion_planning/surround_obstacle_checker">
+            <rect x="1760" y="1120" width="120" height="40" rx="6" ry="6" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1140px; margin-left: 1761px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    surround_
+                                    <br/>
+                                    obstacle_checker
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1820" y="1144" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        surround_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/planning/scenario_planning/lane_driving/motion_planning/obstacle_stop_planner">
+            <rect x="1760" y="1200" width="120" height="40" rx="6" ry="6" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1220px; margin-left: 1761px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    obstacle_stop_
+                                    <br/>
+                                    planner
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1820" y="1224" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        obstacle_stop_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/planning/scenario_planning/parking/costmap_generator">
+            <rect x="2040" y="390" width="120" height="40" rx="6" ry="6" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 410px; margin-left: 2041px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    costmap_generator
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="2100" y="414" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        costmap_generator
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/develop/planning/scenario_planning/common/external_velocity_limit_selector">
+            <rect x="1390" y="1410" width="120" height="40" rx="6" ry="6" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1430px; margin-left: 1391px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    external_velocity_
+                                    <br/>
+                                    limit_selector
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1450" y="1434" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        external_velocity_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 1510 1430 L 1796.13 1430" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1801.38 1430 L 1794.38 1433.5 L 1796.13 1430 L 1794.38 1426.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1430px; margin-left: 1655px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /planning/scenario_planning/max_velocity
+                                <br/>
+                                [tier4_planning_msgs/msg/VelocityLimit]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1655" y="1433" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /planning/scenario_planning/max_velocity...
+                </text>
+            </switch>
+        </g>
+        <path d="M 1760 1220 L 1653 1220 C 1653 1216.1 1647 1216.1 1647 1220 L 1647 1220 L 1450 1220 L 1450 1403.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1450 1408.88 L 1446.5 1401.88 L 1450 1403.63 L 1453.5 1401.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1260px; margin-left: 1450px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /planning/scenario_planning/max_velocity_candidates
+                                <br/>
+                                [tier4_planning_msgs/msg/VelocityLimit]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1450" y="1263" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /planning/scenario_planning/max_velocity_candidates...
+                </text>
+            </switch>
+        </g>
+        <path d="M 1820 1240 L 1820 1290 L 1832.5 1290 L 1832.5 1313.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1832.5 1318.88 L 1829 1311.88 L 1832.5 1313.63 L 1836 1311.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1260px; margin-left: 1820px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                lane_driving/trajectory [Trajectory]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="1263" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    lane_driving/trajectory [Trajectory]
+                </text>
+            </switch>
+        </g>
+        <path d="M 1862.5 1360 L 1862.5 1403.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="stroke"/>
+        <path d="M 1862.5 1408.88 L 1859 1401.88 L 1862.5 1403.63 L 1866 1401.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10" pointer-events="all"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1385px; margin-left: 1863px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                trajectory [Trajectory]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1863" y="1388" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    trajectory [Trajectory]
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/planning/scenario_planning/scenario_selector">
+            <rect x="1802.5" y="1320" width="120" height="40" rx="6" ry="6" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1340px; margin-left: 1804px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    scenario_selector
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1863" y="1344" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        scenario_selector
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/planning/scenario_planning/common/motion_velocity_optimizer">
+            <rect x="1802.5" y="1410" width="120" height="40" rx="6" ry="6" fill="#fff2cc" stroke="#d6b656" pointer-events="all"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1430px; margin-left: 1804px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: all; white-space: normal; overflow-wrap: normal;">
+                                    motion_velocity_
+                                    <br/>
+                                    smoother
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1863" y="1434" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        motion_velocity_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <rect x="1705" y="220" width="230" height="760" rx="34.5" ry="34.5" fill="none" stroke="rgb(0, 0, 0)" stroke-dasharray="3 3" pointer-events="all"/>
+        <rect x="1721.5" y="350" width="200" height="241" fill="none" stroke="none"/>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/main/planning/scenario_planning/lane_driving/behavior_planning/lane_change_plannerbehavior_path_planner">
+            <rect x="1720" y="260" width="200" height="241" rx="30" ry="30" fill="#fff2cc" stroke="#d6b656"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 198px; height: 1px; padding-top: 267px; margin-left: 1721px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    behavior_path_planner
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1820" y="279" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        behavior_path_planner
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <rect x="1760" y="378" width="120" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 393px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                obstacle_avoidance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="397" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    obstacle_avoidance
+                </text>
+            </switch>
+        </g>
+        <rect x="1760" y="418" width="120" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 433px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                pull_over/out
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="437" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    pull_over/out
+                </text>
+            </switch>
+        </g>
+        <rect x="1760" y="458" width="120" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 473px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                side_shift
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="477" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    side_shift
+                </text>
+            </switch>
+        </g>
+        <rect x="1760" y="336" width="120" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 351px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                lane_change
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="355" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    lane_change
+                </text>
+            </switch>
+        </g>
+        <rect x="1760" y="298" width="120" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 313px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                lane_following
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="317" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    lane_following
+                </text>
+            </switch>
+        </g>
+        <rect x="1830" y="230" width="90" height="20.3" fill="none" stroke="none"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 240px; margin-left: 1831px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                &lt;Lane Driving&gt;
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1875" y="244" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    &lt;Lane Driving&gt;
+                </text>
+            </switch>
+        </g>
+        <rect x="1760" y="840" width="120" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 855px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                no_stopping_area
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="859" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    no_stopping_area
+                </text>
+            </switch>
+        </g>
+        <rect x="1760" y="800" width="120" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 815px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                occlusion_spot
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="819" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    occlusion_spot
+                </text>
+            </switch>
+        </g>
+        <rect x="1760" y="760" width="120" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 775px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                intersection
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="779" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    intersection
+                </text>
+            </switch>
+        </g>
+        <rect x="1760" y="720" width="120" height="28" rx="4.2" ry="4.2" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 734px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                traffic_light
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="738" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    traffic_light
+                </text>
+            </switch>
+        </g>
+        <rect x="1760" y="680" width="120" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 695px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                cross_walk
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="699" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    cross_walk
+                </text>
+            </switch>
+        </g>
+        <rect x="1760" y="640" width="120" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 655px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                blind_spot
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="659" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    blind_spot
+                </text>
+            </switch>
+        </g>
+        <rect x="1760" y="600" width="120" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 615px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                detection_area
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="619" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    detection_area
+                </text>
+            </switch>
+        </g>
+        <rect x="1760" y="880" width="120" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 895px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                stop_line
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="899" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    stop_line
+                </text>
+            </switch>
+        </g>
+        <path d="M 1820.93 120 L 1820.45 253.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1820.43 258.88 L 1816.96 251.87 L 1820.45 253.63 L 1823.96 251.89 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1821 120 L 1821 190 L 2020 190 L 2020 293.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 2020 298.88 L 2016.5 291.88 L 2020 293.63 L 2023.5 291.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 150px; margin-left: 1821px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /planning/mission_planning/route
+                                <br/>
+                                [autoware_auto_planning_msgs/HADMapRoute]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1821" y="153" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /planning/mission_planning/route...
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/planning/mission_planning/mission_planner">
+            <rect x="1761" y="80" width="120" height="40" rx="6" ry="6" fill="#fff2cc" stroke="#d6b656"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 100px; margin-left: 1762px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    mission_planner
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1821" y="104" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        mission_planner
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 1820 501 L 1820 563.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1820 568.88 L 1816.5 561.88 L 1820 563.63 L 1823.5 561.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 536px; margin-left: 1820px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                behavior_planning/path_with_lane_id
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="539" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    behavior_planning/path_with_lane_id
+                </text>
+            </switch>
+        </g>
+        <path d="M 1820 980 L 1820 1033.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1820 1038.88 L 1816.5 1031.88 L 1820 1033.63 L 1823.5 1031.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1010px; margin-left: 1820px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                behavior_planning/path
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="1013" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    behavior_planning/path
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/planning/scenario_planning/parking/freespace_planner">
+            <rect x="1960" y="300" width="120" height="40" rx="6" ry="6" fill="#fff2cc" stroke="#d6b656"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 320px; margin-left: 1961px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    freespace_planner
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="2020" y="324" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        freespace_planner
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <rect x="1950" y="220" width="230" height="250" rx="34.5" ry="34.5" fill="none" stroke="rgb(0, 0, 0)" stroke-dasharray="3 3"/>
+        <path d="M 2100 390 L 2100 320 L 2086.37 320" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 2081.12 320 L 2088.12 316.5 L 2086.37 320 L 2088.12 323.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 360px; margin-left: 2100px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                costmap_generator/occupancy_grid
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2100" y="363" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    costmap_generator/occupancy_grid
+                </text>
+            </switch>
+        </g>
+        <path d="M 1821 40 L 1821 73.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1821 78.88 L 1817.5 71.88 L 1821 73.63 L 1824.5 71.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 60px; margin-left: 1821px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                goal
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1821" y="63" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    goal
+                </text>
+            </switch>
+        </g>
+        <rect x="1760" y="920" width="120" height="30" rx="4.5" ry="4.5" fill="#fff2cc" stroke="#d6b656"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 935px; margin-left: 1761px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                virtual_stop_line
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1820" y="939" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    virtual_stop_line
+                </text>
+            </switch>
+        </g>
+        <rect x="2237" y="1610" width="120" height="60" rx="9" ry="9" fill="#d5e8d4" stroke="#82b366"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2238px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                Perception
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2297" y="1644" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Perception
+                </text>
+            </switch>
+        </g>
+        <path d="M 900 712.5 L 900 762 L 1049 762 L 1049 786.13" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1049 791.38 L 1045.5 784.38 L 1049 786.13 L 1052.5 784.38 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 742px; margin-left: 900px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                centerpoint/objects
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="900" y="746" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    centerpoint/objects
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/develop/perception/object_recognition/detection/lidar_centerpoint">
+            <rect x="830" y="672.5" width="140" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 138px; height: 1px; padding-top: 692px; margin-left: 831px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    lidar_centerpoint
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="900" y="696" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        lidar_centerpoint
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 1049 1032.5 L 1049 1097.5 L 1049 1123.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1049 1128.88 L 1045.5 1121.88 L 1049 1123.63 L 1052.5 1121.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1082px; margin-left: 1049px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                /perception/object_recognition/objects
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1049" y="1086" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /perception/object_recognition/objects
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/perception/object_recognition/prediction/map_based_prediction">
+            <rect x="989" y="992.5" width="120" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1012px; margin-left: 990px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    map_based_
+                                    <br/>
+                                    prediction
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1049" y="1016" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        map_based_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 1500 430 L 1500 473.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1500 478.88 L 1496.5 471.88 L 1500 473.63 L 1503.5 471.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 455px; margin-left: 1500px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                traffic_light_detection/rough/rois
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1500" y="458" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    traffic_light_detection/rough/rois
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/perception/traffic_light_recognition/traffic_light_map_based_detector">
+            <rect x="1440" y="390" width="120" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 410px; margin-left: 1441px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    traffic_light_map_
+                                    <br/>
+                                    based_detector
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1500" y="414" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        traffic_light_map_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 1049 832.5 L 1049 870.13" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1049 875.38 L 1045.5 868.38 L 1049 870.13 L 1052.5 868.38 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 852px; margin-left: 1049px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                detection/objects
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1049" y="856" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    detection/objects
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/perception/traffic_light_recognition/traffic_light_classifier">
+            <rect x="1440" y="570" width="120" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 590px; margin-left: 1441px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    traffic_light_
+                                    <br/>
+                                    classifier
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1500" y="594" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        traffic_light_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/perception/traffic_light_recognition/traffic_light_ssd_fine_detector">
+            <rect x="1440" y="480" width="120" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 500px; margin-left: 1441px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    traffic_light_
+                                    <br/>
+                                    ssd_fine_detector
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1500" y="504" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        traffic_light_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 1049 916.5 L 1049 986.13" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1049 991.38 L 1045.5 984.38 L 1049 986.13 L 1052.5 984.38 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 932px; margin-left: 1049px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                tracking/objects
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1049" y="935" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    tracking/objects
+                </text>
+            </switch>
+        </g>
+        <path d="M 1500 210 L 1500 383.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1500 388.88 L 1496.5 381.88 L 1500 383.63 L 1503.5 381.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 270px; margin-left: 1500px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                route,
+                                <br/>
+                                vector_map
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1500" y="273" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    route,...
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/perception/object_recognition/tracking/multi_object_tracker">
+            <rect x="989" y="876.5" width="120" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 897px; margin-left: 990px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    multi_object_
+                                    <br/>
+                                    tracker
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1049" y="900" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        multi_object_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 1500 610 L 1500 734 L 1647 734 C 1647 730.1 1653 730.1 1653 734 L 1653 734 L 1753.63 734" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1758.88 734 L 1751.88 737.5 L 1753.63 734 L 1751.88 730.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 715px; margin-left: 1500px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                traffic_light_states
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1500" y="718" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    traffic_light_states
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/develop/perception/object_recognition/detection/tensorrt_yolo">
+            <rect x="860" y="480" width="90" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 88px; height: 1px; padding-top: 500px; margin-left: 861px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    tensorrt_yolo
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="905" y="504" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        tensorrt_yolo
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 1140 640 L 1140 660 L 1140 650 L 1140 663.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1140 668.88 L 1136.5 661.88 L 1140 663.63 L 1143.5 661.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/develop/perception/object_recognition/detection/roi_cluster_fusion">
+            <rect x="1070" y="600" width="140" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 138px; height: 1px; padding-top: 620px; margin-left: 1071px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    roi_cluster_fusion
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1140" y="624" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        roi_cluster_fusion
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/develop/perception/object_recognition/detection/object_merger">
+            <rect x="994" y="792.5" width="110" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 108px; height: 1px; padding-top: 812px; margin-left: 995px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    object_association
+                                    <br/>
+                                    _merger
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1049" y="816" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        object_association...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 1140 710 L 1140 690 L 1138 762 L 1049 762 L 1049 786.13" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1049 791.38 L 1045.5 784.38 L 1049 786.13 L 1052.5 784.38 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 744px; margin-left: 1144px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: nowrap;">
+                                camera_lidar_fusion/objects
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1144" y="747" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    c...
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/develop/perception/object_recognition/detection/object_range_splitter">
+            <rect x="1070" y="670" width="140" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 138px; height: 1px; padding-top: 690px; margin-left: 1071px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    object_range_splitter
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1140" y="694" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        object_range_splitter
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 1140 580 L 1140 593.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 1140 598.88 L 1136.5 591.88 L 1140 593.63 L 1143.5 591.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/develop/perception/object_recognition/detection/shape_estimation">
+            <rect x="1070" y="540" width="140" height="40" rx="6" ry="6" fill="#d5e8d4" stroke="#82b366"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 138px; height: 1px; padding-top: 560px; margin-left: 1071px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    shape_estimation
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1140" y="564" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        shape_estimation
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <rect x="2360" y="1110" width="680" height="70" rx="10.5" ry="10.5" fill="#b0e3e6" stroke="#0e8088"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 678px; height: 1px; padding-top: 1145px; margin-left: 2362px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                vehicle_interface
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2362" y="1149" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px">
+                    vehicle_interface
+                </text>
+            </switch>
+        </g>
+        <rect x="2666" y="1127" width="120" height="40" rx="6" ry="6" fill="#b0e3e6" stroke="#0e8088"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1147px; margin-left: 2667px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                g30_interface
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2726" y="1151" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    g30_interface
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/vehicle/raw_vehicle_cmd_converter">
+            <rect x="2535" y="870" width="120" height="40" rx="6" ry="6" fill="#b0e3e6" stroke="#0e8088"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 890px; margin-left: 2536px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    raw_vehicle_cmd_
+                                    <br/>
+                                    converter
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="2595" y="894" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        raw_vehicle_cmd_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 2595 910 L 2595 1010 L 2595 1103.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 2595 1108.88 L 2591.5 1101.88 L 2595 1103.63 L 2598.5 1101.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 950px; margin-left: 2615px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /vehicle/command/actuation_cmd
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2615" y="953" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /vehicle/command/actuation_cmd
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/vehicle/as">
+            <rect x="2510" y="1127" width="120" height="40" rx="6" ry="6" fill="#b0e3e6" stroke="#0e8088"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1147px; margin-left: 2511px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    pacmod_interface
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="2570" y="1151" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        pacmod_interface
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <rect x="2840" y="1610" width="120" height="60" rx="9" ry="9" fill="#b0e3e6" stroke="#0e8088"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2841px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                VehicleInterface
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2900" y="1644" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    VehicleInterface
+                </text>
+            </switch>
+        </g>
+        <path d="M 2425.02 1110.77 L 2424.05 976.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 2424.01 971.12 L 2427.56 978.09 L 2424.05 976.37 L 2420.56 978.14 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 1046px; margin-left: 2362px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /vehicle/status/velocity_status
+                                <br/>
+                                /vehicle/status/steering_status
+                                <br/>
+                                /vehicle/status/turn_indicators_status
+                                <br/>
+                                /vehicle/status/gear_status
+                                <br/>
+                                /vehicle/status/control_mode
+                                <br/>
+                                /vehicle/status/
+                                <span style="text-align: center">
+                                    actuation_status
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2362" y="1050" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px">
+                    /vehicle/s...
+                </text>
+            </switch>
+        </g>
+        <path d="M 2570 1173.37 L 2570 1208.5 L 2569.15 1243.63" fill="none" stroke="#666666" stroke-miterlimit="10"/>
+        <path d="M 2570 1168.12 L 2573.5 1175.12 L 2570 1173.37 L 2566.5 1175.12 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10"/>
+        <path d="M 2569.03 1248.88 L 2565.7 1241.8 L 2569.15 1243.63 L 2572.69 1241.97 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1216px; margin-left: 2569px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /pacmod/**
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2569" y="1219" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /pacmod/**
+                </text>
+            </switch>
+        </g>
+        <rect x="2983" y="1610" width="120" height="60" rx="9" ry="9" fill="#f5f5f5" stroke="#666666"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2984px;">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                Vehicle
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3043" y="1644" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Vehicle
+                </text>
+            </switch>
+        </g>
+        <path d="M 2569 1290 L 2569 1323.63" fill="none" stroke="#666666" stroke-miterlimit="10"/>
+        <path d="M 2569 1328.88 L 2565.5 1321.88 L 2569 1323.63 L 2572.5 1321.88 Z" fill="#666666" stroke="#666666" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1310px; margin-left: 2569px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                &lt;CAN&gt;
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2569" y="1313" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    &lt;CAN&gt;
+                </text>
+            </switch>
+        </g>
+        <rect x="2509" y="1330" width="120" height="40" rx="6" ry="6" fill="#f5f5f5" stroke="#666666"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1350px; margin-left: 2510px;">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                JapanTaxi
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2569" y="1354" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    JapanTaxi
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="http://wiki.ros.org/pacmod3">
+            <rect x="2509" y="1250" width="120" height="40" rx="6" ry="6" fill="#f5f5f5" stroke="#666666"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1270px; margin-left: 2510px;">
+                            <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    pacmod3
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="2569" y="1274" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        pacmod3
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <rect x="2666" y="1330" width="120" height="40" rx="6" ry="6" fill="#f5f5f5" stroke="#666666"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1350px; margin-left: 2667px;">
+                        <div data-drawio-colors="color: #333333; " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(51, 51, 51); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                YMC GolfCart
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2726" y="1354" fill="#333333" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    YMC GolfCart
+                </text>
+            </switch>
+        </g>
+        <path d="M 420 350 L 420 403.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 420 408.88 L 416.5 401.88 L 420 403.63 L 423.5 401.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 380px; margin-left: 420px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                top/velodyne_packets
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="420" y="383" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    top/velodyne_packets
+                </text>
+            </switch>
+        </g>
+        <rect x="360" y="300" width="120" height="50" rx="7.5" ry="7.5" fill="#e1d5e7" stroke="#9673a6"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 325px; margin-left: 361px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                lidar_driver
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="420" y="329" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    lidar_driver
+                </text>
+            </switch>
+        </g>
+        <path d="M 420 650 L 420 683.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 420 688.88 L 416.5 681.88 L 420 683.63 L 423.5 681.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 670px; margin-left: 420px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                top/rectified/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="420" y="673" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    top/rectified/pointcloud
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/velodyne_vls/blob/tier4/master/velodyne_pointcloud/src/conversions/interpolate_node.cc">
+            <rect x="360" y="620" width="120" height="30" rx="4.5" ry="4.5" fill="#e1d5e7" stroke="#9673a6"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 635px; margin-left: 361px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    fix_distortion
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="420" y="639" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        fix_distortion
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 420 440 L 420 473.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 420 478.88 L 416.5 471.88 L 420 473.63 L 423.5 471.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 460px; margin-left: 420px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                top/pointcloud_raw
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="420" y="463" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    top/pointcloud_raw
+                </text>
+            </switch>
+        </g>
+        <rect x="360" y="410" width="120" height="30" rx="4.5" ry="4.5" fill="#e1d5e7" stroke="#9673a6"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 425px; margin-left: 361px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                packets_to_
+                                <br/>
+                                pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="420" y="429" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    packets_to_...
+                </text>
+            </switch>
+        </g>
+        <path d="M 420 510 L 420 543.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 420 548.88 L 416.5 541.88 L 420 543.63 L 423.5 541.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 530px; margin-left: 420px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                top/self_cropped/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="420" y="533" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    top/self_cropped/pointcloud
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/sensing/preprocessor/pointcloud/pointcloud_preprocessor/src">
+            <rect x="360" y="480" width="120" height="30" rx="4.5" ry="4.5" fill="#e1d5e7" stroke="#9673a6"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 495px; margin-left: 361px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    crop_box_
+                                    <br/>
+                                    filter_self
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="420" y="499" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        crop_box_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 420 580 L 420 613.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 420 618.88 L 416.5 611.88 L 420 613.63 L 423.5 611.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 600px; margin-left: 420px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                top/mirror_cropped/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="420" y="603" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    top/mirror_cropped/pointcloud
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/sensing/preprocessor/pointcloud/pointcloud_preprocessor/src">
+            <rect x="360" y="550" width="120" height="30" rx="4.5" ry="4.5" fill="#e1d5e7" stroke="#9673a6"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 565px; margin-left: 361px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    crop_box_
+                                    <br/>
+                                    filter_mirror
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="420" y="569" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        crop_box_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/sensing/preprocessor/pointcloud/pointcloud_preprocessor/src/outlier_filter">
+            <rect x="360" y="690" width="120" height="30" rx="4.5" ry="4.5" fill="#e1d5e7" stroke="#9673a6"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 705px; margin-left: 361px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    ring_outlier_filter
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="420" y="709" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        ring_outlier_filter
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 250 350 L 250 403.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 250 408.88 L 246.5 401.88 L 250 403.63 L 253.5 401.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 380px; margin-left: 250px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                lidar/*/velodyne_packets
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="250" y="383" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    lidar/*/velodyne_packets
+                </text>
+            </switch>
+        </g>
+        <rect x="190" y="300" width="120" height="50" rx="7.5" ry="7.5" fill="#e1d5e7" stroke="#9673a6"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 325px; margin-left: 191px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                lidar_drivers
+                                <br/>
+                                (left,right,front_right, front_left,rear)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="250" y="329" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    lidar_drivers...
+                </text>
+            </switch>
+        </g>
+        <path d="M 250 650 L 250 683.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 250 688.88 L 246.5 681.88 L 250 683.63 L 253.5 681.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 670px; margin-left: 250px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                <span style="color: rgb(0 , 0 , 0) ; font-family: &quot;helvetica&quot; ; font-size: 11px ; font-style: normal ; font-weight: 400 ; letter-spacing: normal ; text-align: center ; text-indent: 0px ; text-transform: none ; word-spacing: 0px ; background-color: rgb(255 , 255 , 255) ; display: inline ; float: none">
+                                    */rectified/pointcloud
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="250" y="673" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    */rectified/pointcloud
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/velodyne_vls/blob/tier4/master/velodyne_pointcloud/src/conversions/interpolate_node.cc">
+            <rect x="190" y="620" width="120" height="30" rx="4.5" ry="4.5" fill="#e1d5e7" stroke="#9673a6"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 635px; margin-left: 191px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    fix_distortion
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="250" y="639" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        fix_distortion
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 250 440 L 250 473.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 250 478.88 L 246.5 471.88 L 250 473.63 L 253.5 471.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 460px; margin-left: 250px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                <span style="color: rgb(0 , 0 , 0) ; font-family: &quot;helvetica&quot; ; font-size: 11px ; font-style: normal ; font-weight: 400 ; letter-spacing: normal ; text-align: center ; text-indent: 0px ; text-transform: none ; word-spacing: 0px ; background-color: rgb(255 , 255 , 255) ; display: inline ; float: none">
+                                    */pointcloud_raw
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="250" y="463" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    */pointcloud_raw
+                </text>
+            </switch>
+        </g>
+        <rect x="190" y="410" width="120" height="30" rx="4.5" ry="4.5" fill="#e1d5e7" stroke="#9673a6"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 425px; margin-left: 191px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                packets_to_
+                                <br/>
+                                pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="250" y="429" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    packets_to_...
+                </text>
+            </switch>
+        </g>
+        <path d="M 250 510 L 250 543.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 250 548.88 L 246.5 541.88 L 250 543.63 L 253.5 541.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 530px; margin-left: 250px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                <span style="color: rgb(0 , 0 , 0) ; font-family: &quot;helvetica&quot; ; font-size: 11px ; font-style: normal ; font-weight: 400 ; letter-spacing: normal ; text-align: center ; text-indent: 0px ; text-transform: none ; word-spacing: 0px ; background-color: rgb(255 , 255 , 255) ; display: inline ; float: none">
+                                    */self_cropped/pointcloud
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="250" y="533" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    */self_cropped/pointcloud
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/sensing/preprocessor/pointcloud/pointcloud_preprocessor/src">
+            <rect x="190" y="480" width="120" height="30" rx="4.5" ry="4.5" fill="#e1d5e7" stroke="#9673a6"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 495px; margin-left: 191px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    crop_box_
+                                    <br/>
+                                    filter_self
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="250" y="499" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        crop_box_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 250 580 L 250 613.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 250 618.88 L 246.5 611.88 L 250 613.63 L 253.5 611.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 600px; margin-left: 250px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                <span style="color: rgb(0 , 0 , 0) ; font-family: &quot;helvetica&quot; ; font-size: 11px ; font-style: normal ; font-weight: 400 ; letter-spacing: normal ; text-align: center ; text-indent: 0px ; text-transform: none ; word-spacing: 0px ; background-color: rgb(255 , 255 , 255) ; display: inline ; float: none">
+                                    */mirror_cropped/pointcloud
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="250" y="603" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    */mirror_cropped/pointcloud
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/sensing/preprocessor/pointcloud/pointcloud_preprocessor/src">
+            <rect x="190" y="550" width="120" height="30" rx="4.5" ry="4.5" fill="#e1d5e7" stroke="#9673a6"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 565px; margin-left: 191px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    crop_box_
+                                    <br/>
+                                    filter_mirror
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="250" y="569" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        crop_box_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/sensing/preprocessor/pointcloud/pointcloud_preprocessor/src/outlier_filter">
+            <rect x="190" y="690" width="120" height="30" rx="4.5" ry="4.5" fill="#e1d5e7" stroke="#9673a6"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 705px; margin-left: 191px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    ring_outlier_filter
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="250" y="709" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        ring_outlier_filter
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 320 800 L 320 848.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 320 853.88 L 316.5 846.88 L 320 848.63 L 323.5 846.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 820px; margin-left: 320px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                concatenated/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="320" y="823" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    concatenated/pointcloud
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/sensing/preprocessor/pointcloud/pointcloud_preprocessor/src/concatenate_data">
+            <rect x="260" y="760" width="120" height="40" rx="6" ry="6" fill="#e1d5e7" stroke="#9673a6"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 780px; margin-left: 261px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    concat_filter
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="320" y="784" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        concat_filter
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 250 720 L 250 741 L 320 741 L 320 753.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 320 758.88 L 316.5 751.88 L 320 753.63 L 323.5 751.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 400 720 L 400 741 L 320 741 L 320 753.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 320 758.88 L 316.5 751.88 L 320 753.63 L 323.5 751.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/sensing/preprocessor/gnss/gnss_poser">
+            <rect x="0" y="850" width="120" height="40" rx="6" ry="6" fill="#e1d5e7" stroke="#9673a6"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 870px; margin-left: 1px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    gnss_poser
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="60" y="874" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        gnss_poser
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 60 800 L 60 843.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 60 848.88 L 56.5 841.88 L 60 843.63 L 63.5 841.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <rect x="0" y="760" width="120" height="40" rx="6" ry="6" fill="#e1d5e7" stroke="#9673a6"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 780px; margin-left: 1px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                gnss_driver
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="60" y="784" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    gnss_driver
+                </text>
+            </switch>
+        </g>
+        <rect x="483" y="770" width="120" height="40" rx="6" ry="6" fill="#e1d5e7" stroke="#9673a6"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 790px; margin-left: 484px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                imu_driver
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="543" y="794" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    imu_driver
+                </text>
+            </switch>
+        </g>
+        <path d="M 543 810 L 543 883.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 543 888.88 L 539.5 881.88 L 543 883.63 L 546.5 881.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 850px; margin-left: 543px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /sensing/imu/imu_raw
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="543" y="853" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /sensing/imu/imu_raw
+                </text>
+            </switch>
+        </g>
+        <path d="M 420 720 L 420 930 L 340 930 L 340 1133.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 340 1138.88 L 336.5 1131.88 L 340 1133.63 L 343.5 1131.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 980px; margin-left: 340px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /sensing/lidar/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="340" y="983" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /sensing/lidar/pointcloud
+                </text>
+            </switch>
+        </g>
+        <path d="M 480 635 L 720 635 L 720 692.5 L 823.63 692.5" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 828.88 692.5 L 821.88 696 L 823.63 692.5 L 821.88 689 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 623px; margin-left: 660px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                <span style="color: rgb(0 , 0 , 0) ; font-family: &quot;helvetica&quot; ; font-size: 11px ; font-style: normal ; font-weight: 400 ; letter-spacing: normal ; text-align: center ; text-indent: 0px ; text-transform: none ; word-spacing: 0px ; background-color: rgb(255 , 255 , 255) ; display: inline ; float: none">
+                                    /sensing/top/rectified/pointcloud
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="660" y="626" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /sensing/top/rectified/pointcloud
+                </text>
+            </switch>
+        </g>
+        <path d="M 60 890 L 60 1223.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 60 1228.88 L 56.5 1221.88 L 60 1223.63 L 63.5 1221.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1060px; margin-left: 60px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /sensing/gnss/
+                                <br/>
+                                pose_with_covariance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="60" y="1063" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /sensing/gnss/...
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/main/sensing/preprocessor/imu/imu_corrector">
+            <rect x="483" y="890" width="120" height="40" rx="6" ry="6" fill="#e1d5e7" stroke="#9673a6"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 910px; margin-left: 484px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    imu_corrector
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="543" y="914" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        imu_corrector
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 543 930 L 543 1203.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 543 1208.88 L 539.5 1201.88 L 543 1203.63 L 546.5 1201.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1070px; margin-left: 543px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /sensing/imu/imu_data
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="543" y="1073" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /sensing/imu/imu_data
+                </text>
+            </switch>
+        </g>
+        <rect x="1930" y="1610" width="120" height="60" rx="9" ry="9" fill="#e1d5e7" stroke="#9673a6"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 1931px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                Sensing
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="1990" y="1644" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Sensing
+                </text>
+            </switch>
+        </g>
+        <rect x="2083" y="1610" width="120" height="60" rx="9" ry="9" fill="#dae8fc" stroke="#6c8ebf"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2084px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                Localization
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2143" y="1644" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    Localization
+                </text>
+            </switch>
+        </g>
+        <path d="M 340 1268 L 340 1303.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 340 1308.88 L 336.5 1301.88 L 340 1303.63 L 343.5 1301.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1288px; margin-left: 340px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                voxel_grid_downsample/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="340" y="1291" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    voxel_grid_downsample/pointcloud
+                </text>
+            </switch>
+        </g>
+        <rect x="280" y="1228" width="120" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1248px; margin-left: 281px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                voxel_grid_
+                                <br/>
+                                downsample_filter
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="340" y="1252" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    voxel_grid_...
+                </text>
+            </switch>
+        </g>
+        <path d="M 483.36 1499.56 L 483.5 1420 L 406.37 1420" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 401.12 1420 L 408.12 1416.5 L 406.37 1420 L 408.12 1423.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1465px; margin-left: 470px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                pose_twist_fusion_filter/
+                                <br/>
+                                pose_with_covariance_
+                                <br/>
+                                no_yawbias
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="470" y="1468" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    pose_twist_fusion_filter/...
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/localization/pose_twist_fusion_filter/ekf_localizer">
+            <rect x="280" y="1499" width="310" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 308px; height: 1px; padding-top: 1519px; margin-left: 281px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    ekf_localizer
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="435" y="1523" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        ekf_localizer
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 340 1440 L 339.63 1491.95" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 339.54 1497.2 L 336.16 1490.14 L 339.63 1491.95 L 343.16 1490.26 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1460px; margin-left: 340px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                pose_estimator/
+                                <br/>
+                                pose_with_covariance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="340" y="1463" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    pose_estimator/...
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/localization/pose_estimator/ndt_scan_matcher">
+            <rect x="280" y="1400" width="120" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1420px; margin-left: 281px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    ndt_scan_matcher
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="340" y="1424" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        ndt_scan_matcher
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 340 1350 L 340 1393.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 340 1398.88 L 336.5 1391.88 L 340 1393.63 L 343.5 1391.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1375px; margin-left: 340px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                downsample/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="340" y="1378" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    downsample/pointcloud
+                </text>
+            </switch>
+        </g>
+        <rect x="280" y="1310" width="120" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1330px; margin-left: 281px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                random_
+                                <br/>
+                                downsample_filter
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="340" y="1334" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    random_...
+                </text>
+            </switch>
+        </g>
+        <path d="M 120 1250 L 150 1250 L 150 1430 L 273.63 1430" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 278.88 1430 L 271.88 1433.5 L 273.63 1430 L 271.88 1426.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1390px; margin-left: 150px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /initialpose3d
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="150" y="1393" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /initialpose3d
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/localization/util/pose_initializer">
+            <rect x="0" y="1230" width="120" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1250px; margin-left: 1px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    pose_initializer
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="60" y="1254" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        pose_initializer
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 543 1250 L 543 1200 L 544.39 1491.19" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 544.42 1496.44 L 540.89 1489.46 L 544.39 1491.19 L 547.88 1489.42 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1390px; margin-left: 545px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                twist_estimator/twist_with_covariance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="545" y="1393" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    twist_estimator/twist_with_covariance
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/localization/twist_estimator/gyro_odometer">
+            <rect x="483" y="1210" width="120" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1230px; margin-left: 484px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    gyro_odometer
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="543" y="1234" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        gyro_odometer
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 340 1180 L 340 1221.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 340 1226.88 L 336.5 1219.88 L 340 1221.63 L 343.5 1219.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1205px; margin-left: 340px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                measurement_range/pointcloud
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="340" y="1208" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    measurement_range/pointcloud
+                </text>
+            </switch>
+        </g>
+        <rect x="280" y="1140" width="120" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1160px; margin-left: 281px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                crop_box_filter_
+                                <br/>
+                                measurement_range
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="340" y="1164" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    crop_box_filter_...
+                </text>
+            </switch>
+        </g>
+        <rect x="600" y="1130" width="160" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 158px; height: 1px; padding-top: 1150px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                vehicle_velocity_converter
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="680" y="1154" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    vehicle_velocity_converter
+                </text>
+            </switch>
+        </g>
+        <path d="M 336 1540 L 336 1703.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 336 1708.88 L 332.5 1701.88 L 336 1703.63 L 339.5 1701.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1585px; margin-left: 340px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /tf
+                                <br/>
+                                (map to base_link)
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="340" y="1588" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /tf...
+                </text>
+            </switch>
+        </g>
+        <path d="M 440 1640 L 440 1710 L 440 1713.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 440 1718.88 L 436.5 1711.88 L 440 1713.63 L 443.5 1711.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1680px; margin-left: 440px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /localization/kinematic_state
+                                <br/>
+                                [nav_msgs/msg/Odometry]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="440" y="1683" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /localization/kinematic_state...
+                </text>
+            </switch>
+        </g>
+        <rect x="380" y="1600" width="120" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1620px; margin-left: 381px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                stop_filter
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="440" y="1624" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    stop_filter
+                </text>
+            </switch>
+        </g>
+        <rect x="600" y="1590" width="160" height="40" rx="6" ry="6" fill="#dae8fc" stroke="#6c8ebf"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 158px; height: 1px; padding-top: 1610px; margin-left: 601px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                localization_error_monitor
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="680" y="1614" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    localization_error_monitor
+                </text>
+            </switch>
+        </g>
+        <path d="M 590 1519 L 680 1519 L 680 1583.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 680 1588.88 L 676.5 1581.88 L 680 1583.63 L 683.5 1581.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1534px; margin-left: 680px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                pose_twist_fusion_filter/
+                                <br/>
+                                pose_with_covariance
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="680" y="1537" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    pose_twist_fusion_filter/...
+                </text>
+            </switch>
+        </g>
+        <path d="M 680 1630 L 680 1703.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 680 1708.88 L 676.5 1701.88 L 680 1703.63 L 683.5 1701.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1670px; margin-left: 680px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /diagnostics
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="680" y="1673" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /diagnostics
+                </text>
+            </switch>
+        </g>
+        <path d="M 435 1539 L 435 1569.5 L 440 1569.5 L 440 1593.63" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 440 1598.88 L 436.5 1591.88 L 440 1593.63 L 443.5 1591.88 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 1569px; margin-left: 440px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                pose_twist_fusion_filter/
+                                <br/>
+                                kinematic_state
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="440" y="1572" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    pose_twist_fusion_filter/...
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/system/system_monitor">
+            <rect x="3419" y="874" width="180" height="350" rx="27" ry="27" fill="#f8cecc" stroke="#b85450"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe flex-start; justify-content: unsafe center; width: 178px; height: 1px; padding-top: 881px; margin-left: 3420px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    system_monitors
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="3509" y="893" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        system_monitors
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <rect x="2690" y="1610" width="120" height="60" rx="9" ry="9" fill="#f8cecc" stroke="#b85450"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1640px; margin-left: 2691px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                System
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="2750" y="1644" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    System
+                </text>
+            </switch>
+        </g>
+        <rect x="3449" y="904" width="120" height="40" rx="6" ry="6" fill="#f8cecc" stroke="#b85450"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 924px; margin-left: 3450px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                autoware_process_
+                                <br/>
+                                monitor
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3509" y="928" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    autoware_process_...
+                </text>
+            </switch>
+        </g>
+        <rect x="3449" y="954" width="120" height="40" rx="6" ry="6" fill="#f8cecc" stroke="#b85450"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 974px; margin-left: 3450px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                autoware_gpu_
+                                <br/>
+                                monitor
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3509" y="978" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    autoware_gpu_...
+                </text>
+            </switch>
+        </g>
+        <rect x="3449" y="1004" width="120" height="40" rx="6" ry="6" fill="#f8cecc" stroke="#b85450"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1024px; margin-left: 3450px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                autoware_mem_
+                                <br/>
+                                monitor
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3509" y="1028" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    autoware_mem_...
+                </text>
+            </switch>
+        </g>
+        <rect x="3449" y="1058.5" width="120" height="40" rx="6" ry="6" fill="#f8cecc" stroke="#b85450"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1079px; margin-left: 3450px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                autoware_hdd_
+                                <br/>
+                                monitor
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3509" y="1082" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    autoware_hdd_...
+                </text>
+            </switch>
+        </g>
+        <rect x="3449" y="1109" width="120" height="40" rx="6" ry="6" fill="#f8cecc" stroke="#b85450"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1129px; margin-left: 3450px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                autoware_net_
+                                <br/>
+                                monitor
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3509" y="1133" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    autoware_net_...
+                </text>
+            </switch>
+        </g>
+        <rect x="3449" y="1164" width="120" height="40" rx="6" ry="6" fill="#f8cecc" stroke="#b85450"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1184px; margin-left: 3450px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                autoware_ntp_
+                                <br/>
+                                monitor
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3509" y="1188" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                    autoware_ntp_...
+                </text>
+            </switch>
+        </g>
+        <path d="M 3170 1027 L 3170 970 L 3170 960.37" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 3170 955.12 L 3173.5 962.12 L 3170 960.37 L 3166.5 962.12 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 992px; margin-left: 3170px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                /system/emergency/hazard_status
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3170" y="995" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px" text-anchor="middle">
+                    /system/emergency/hazard_status
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/system/autoware_error_monitor">
+            <rect x="3110" y="1027" width="120" height="90" rx="13.5" ry="13.5" fill="#f8cecc" stroke="#b85450"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 1072px; margin-left: 3111px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    autoware_error_
+                                    <br/>
+                                    monitor
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="3170" y="1076" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        autoware_error_...
+                    </text>
+                </switch>
+            </g>
+        </a>
+        <path d="M 3170 914 L 3170 750 L 3036.37 750" fill="none" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <path d="M 3031.12 750 L 3038.12 746.5 L 3036.37 750 L 3038.12 753.5 Z" fill="rgb(0, 0, 0)" stroke="rgb(0, 0, 0)" stroke-miterlimit="10"/>
+        <g transform="translate(-0.5 -0.5)">
+            <switch>
+                <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                    <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 830px; margin-left: 3116px;">
+                        <div data-drawio-colors="color: rgb(0, 0, 0); background-color: rgb(255, 255, 255); " style="box-sizing: border-box; font-size: 0px; text-align: left;">
+                            <div style="display: inline-block; font-size: 11px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; background-color: rgb(255, 255, 255); white-space: nowrap;">
+                                <div>
+                                    /system/emergency/control_cmd [AckermannControlCommand]
+                                </div>
+                                <div>
+                                    /system/emergency/gear_cmd [GearCommand]
+                                </div>
+                                <div>
+                                    /system/emergency/hazard_lights_cmd [HazardLightsCommand]
+                                </div>
+                                /system/emergency/emergency_state [EmergencyStateStamped]
+                            </div>
+                        </div>
+                    </div>
+                </foreignObject>
+                <text x="3116" y="833" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="11px">
+                    /system/emergency/control_cmd [AckermannControlCommand]...
+                </text>
+            </switch>
+        </g>
+        <a xlink:href="https://github.com/tier4/autoware.iv/tree/master/system/emergency_handler">
+            <rect x="3110" y="914" width="120" height="40" rx="6" ry="6" fill="#f8cecc" stroke="#b85450"/>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility" style="overflow: visible; text-align: left;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 118px; height: 1px; padding-top: 934px; margin-left: 3111px;">
+                            <div data-drawio-colors="color: rgb(0, 0, 0); " style="box-sizing: border-box; font-size: 0px; text-align: center;">
+                                <div style="display: inline-block; font-size: 12px; font-family: Helvetica; color: rgb(0, 0, 0); line-height: 1.2; pointer-events: none; white-space: normal; overflow-wrap: normal;">
+                                    emergency_handler
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="3170" y="938" fill="rgb(0, 0, 0)" font-family="Helvetica" font-size="12px" text-anchor="middle">
+                        emergency_handler
+                    </text>
+                </switch>
+            </g>
+        </a>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.diagrams.net/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Viewer does not support full SVG 1.1
+            </text>
+        </a>
+    </switch>
+</svg>


### PR DESCRIPTION
This is an overall node diagram for autoware universe. 

Note: the current diagram follows the TIERIV's fork implementation. I create this PR as just a reference.

![image](https://user-images.githubusercontent.com/21360593/157194872-a1e5b50e-8d2d-474a-a66e-92e8f5c050f4.png)
