### PR TITLE
docs: fix planning-simulation.md

### DIFF
--- a/docs/tutorials/ad-hoc-simulation/planning-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/planning-simulation.md
@@ -49,6 +49,7 @@
 5. Engage the ego vehicle.
 
    ```bash
+   source ~/autoware/install/setup.bash
    ros2 topic pub /autoware/engage autoware_auto_vehicle_msgs/msg/Engage "engage: true" -1
    ```
 


### PR DESCRIPTION
## Description

add `source ~/autoware/install/setup.bash` before `ros2 topic pub /autoware/engage autoware_auto_vehicle_msgs/msg/Engage "engage: true" -1` in the tutorial page of planning_simulation.

Without souring setup.bash, `ros2 topic pub...` will fail with the error message `The passed message type is invalid`.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
