### PR TITLE
docs: add how to run docker without NVIDIA GPU.

### DIFF
--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -42,10 +42,16 @@ You might need to log out and log back to make the current user able to use dock
     Before proceeding, confirm and agree with the [NVIDIA Deep Learning Container license](https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license).
     By pulling and using the Autoware Universe images, you accept the terms and conditions of the license.
 
-1. Launch a Docker container
+1. Launch a Docker container.
 
    ```bash
    rocker --nvidia --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest
+   ```
+
+   If you want to run container without using NVIDIA GPU:
+
+   ```bash
+   rocker -e LIBGL_ALWAYS_SOFTWARE=1 --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest
    ```
 
    See [here](https://github.com/autowarefoundation/autoware/tree/main/docker/README.md) for more advanced usage.
@@ -75,24 +81,35 @@ You might need to log out and log back to make the current user able to use dock
 
    ```bash
    docker pull ghcr.io/autowarefoundation/autoware-universe:latest
+   ```
+
+2. Launch the Docker container.
+
+   ```bash
    rocker --nvidia --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest
    ```
 
-2. Update the `.repos` file.
+   If you want to run container without using NVIDIA GPU:
+
+   ```bash
+   rocker -e LIBGL_ALWAYS_SOFTWARE=1 --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest
+   ```
+
+3. Update the `.repos` file.
 
    ```bash
    cd autoware
    git pull
    ```
 
-3. Update the repositories.
+4. Update the repositories.
 
    ```bash
    vcs import src < autoware.repos
    vcs pull
    ```
 
-4. Build the workspace.
+5. Build the workspace.
 
    ```bash
    colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release


### PR DESCRIPTION
## Description

The command in docker installation tutorial is only for NVIDIA GPU.
If running container without GPU, it'll fail.

Thanks to @kenji-miyake for providing solution [here](https://github.com/autowarefoundation/autoware-documentation/pull/73#issuecomment-1090136882).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
