### PR TITLE
docs: add instructions to make a documentation page

### DIFF
--- a/docs/contributing/documentation-guidelines/index.md
+++ b/docs/contributing/documentation-guidelines/index.md
@@ -3,5 +3,6 @@
 ## Instructions to add documentation
 
 There are two ways to contribute to the documentation page.
+
 1. If you can make a documentation page based on your knowledge, please [send a pull request](https://github.com/autowarefoundation/autoware-documentation/pulls). If you are unaware of if you can open a pull request or unaware of the format, you can ask on the [feature requests page](https://github.com/autowarefoundation/autoware/discussions/categories/feature-requests).
 2. If you are curious about what to write or whether your contribution is worthwhile or not, you can ask on [Q&A page](https://github.com/autowarefoundation/autoware/discussions/categories/q-a).

--- a/docs/contributing/documentation-guidelines/index.md
+++ b/docs/contributing/documentation-guidelines/index.md
@@ -1,5 +1,7 @@
 # Documentation guidelines
 
-!!! warning
+## Instructions to add documentation
 
-    Under Construction
+There are two ways to contribute to the documentation page.
+1. If you can make a documentation page based on your knowledge, please [send a pull request](https://github.com/autowarefoundation/autoware-documentation/pulls). If you are unaware of if you can open a pull request or unaware of the format, you can ask on the [feature requests page](https://github.com/autowarefoundation/autoware/discussions/categories/feature-requests).
+2. If you are curious about what to write or whether your contribution is worthwhile or not, you can ask on [Q&A page](https://github.com/autowarefoundation/autoware/discussions/categories/q-a).

--- a/docs/help/support-guidelines.md
+++ b/docs/help/support-guidelines.md
@@ -52,6 +52,8 @@ If your question is not answered within a week, then @mention the maintainers to
 Also, there are other discussion types such as [feature requests](https://github.com/autowarefoundation/autoware/discussions/categories/feature-requests) or [design discussions](https://github.com/autowarefoundation/autoware/discussions/categories/design).
 Feel free to open or join such discussions.
 
+Once the problem is resolved, turn the knowledge into the documentation!
+
 ## GitHub Issues
 
 If you have a problem and you have confirmed it is a bug, find the appropriate repository and create a new issue there.


### PR DESCRIPTION
## Description

Add instructions to make a documentation page

https://github.com/autowarefoundation/autoware-documentation/issues/84

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
