### PR TITLE
docs: add a contribution flow chart

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -4,9 +4,8 @@
 
 Did you find a software bug? -> Open an issue in the corresponding software repository
 Did you find strange behavior? -> [Ask in Q&A](https://github.com/autowarefoundation/autoware/discussions/categories/q-a)
-Do you have questions about Autoware functionality? ->  [Ask in Q&A](https://github.com/autowarefoundation/autoware/discussions/categories/q-a)
+Do you have questions about Autoware functionality? -> [Ask in Q&A](https://github.com/autowarefoundation/autoware/discussions/categories/q-a)
 Do you want to add new features to Autoware? -> [Make a feature request](https://github.com/autowarefoundation/autoware/discussions/categories/feature-requests)
-
 
 This page explains how to contribute to Autoware.
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -1,5 +1,13 @@
 # Contributing
 
+## Contribution flow
+
+Did you find a software bug? -> Open an issue in the corresponding software repository
+Did you find strange behavior? -> [Ask in Q&A](https://github.com/autowarefoundation/autoware/discussions/categories/q-a)
+Do you have questions about Autoware functionality? ->  [Ask in Q&A](https://github.com/autowarefoundation/autoware/discussions/categories/q-a)
+Do you want to add new features to Autoware? -> [Make a feature request](https://github.com/autowarefoundation/autoware/discussions/categories/feature-requests)
+
+
 This page explains how to contribute to Autoware.
 
 First, conform to the [Code of conduct](#contribution-workflows) section for the general manners in contributions.


### PR DESCRIPTION
## Description

The current documentation shows what contribution tools we have (such as GitHub discussions, issues, discord).
I would like to change the documentation structure so that contributors can choose appropriate tools based on what they want to do. For example, in the current documentation, when contributors want to ask a question about Autoware, it is not much clear where they should see to choose the appropriate tool. (It's Q&A. but it is not clearly written in the support guideline, also, it is hard to know where they should see to choose it)
This PR is to add a text based chart to choose an appropriate tool based on contribution. 

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
