### PR TITLE
docs: fix broken anchor

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -8,7 +8,7 @@ As a contributor, here are the guidelines that we would like you to follow for A
 - [What should I know before I get started?](#what-should-i-know-before-i-get-started)
   - [Autoware concepts](#autoware-concepts)
   - [Contributing to open source projects](#contributing-to-open-source-projects)
-- [How can I get help?](#how-can-I-get-help)
+- [How can I get help?](#how-can-i-get-help)
 - [How can I contribute?](#how-can-i-contribute)
   - [Participate in discussions](#discussions)
   - [Join a working group](#working-groups)


### PR DESCRIPTION
Signed-off-by: Lalith Vipulananthan <lalith.vipulananthan@tier4.jp>

## Description

Fixing broken anchor in the table of contents for the "How can I get help?" section. GitHub's markdown ignores capitals in anchor links but it seems that MkDocs is more strict.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
