### PR TITLE
docs: add more concrete example cases of making PRs

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -83,11 +83,10 @@ You can submit pull requests for small changes such as:
 - Fixing warnings detected by compilers or analysis tools
 - Making small changes to a single package
 
-If your pull request is a large change such as
+If your pull request is a large change, discuss with the maintainers before submission. Doing so ensures that the proposed change is in line with Autoware's design philosophy and current development plans. If you're not sure where to have that conversation, then [create a new Q&A discussion](https://github.com/autowarefoundation/autoware/discussions/new?category=q-a).
 
+Examples of large changes include:
 - Adding a new feature to Autoware
-- Adding a new page to the documentation
-
-discuss with the maintainers before submission. Doing so ensures that the proposed change is in line with Autoware's design philosophy and current development plans. If you're not sure where to have that conversation, then [create a new Q&A discussion](https://github.com/autowarefoundation/autoware/discussions/new?category=q-a).
+- Adding a new documentation page or section
 
 For more information on how to submit a good pull request, have a read of our [pull request guidelines](pull-request-guidelines/index.md) and don't forget to review the required [license notations](license.md)!

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -86,6 +86,7 @@ You can submit pull requests for small changes such as:
 If your pull request is a large change, discuss with the maintainers before submission. Doing so ensures that the proposed change is in line with Autoware's design philosophy and current development plans. If you're not sure where to have that conversation, then [create a new Q&A discussion](https://github.com/autowarefoundation/autoware/discussions/new?category=q-a).
 
 Examples of large changes include:
+
 - Adding a new feature to Autoware
 - Adding a new documentation page or section
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -83,6 +83,11 @@ You can submit pull requests for small changes such as:
 - Fixing warnings detected by compilers or analysis tools
 - Making small changes to a single package
 
-If your pull request is a large change not covered by the examples above, discuss with the maintainers before submission. Doing so ensures that the proposed change is in line with Autoware's design philosophy and current development plans. If you're not sure where to have that conversation, then [create a new Q&A discussion](https://github.com/autowarefoundation/autoware/discussions/new?category=q-a).
+If your pull request is a large change such as
+
+* Adding a new feature to Autoware
+* Adding a new page to the documentation
+
+discuss with the maintainers before submission. Doing so ensures that the proposed change is in line with Autoware's design philosophy and current development plans. If you're not sure where to have that conversation, then [create a new Q&A discussion](https://github.com/autowarefoundation/autoware/discussions/new?category=q-a).
 
 For more information on how to submit a good pull request, have a read of our [pull request guidelines](pull-request-guidelines/index.md) and don't forget to review the required [license notations](license.md)!

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -85,8 +85,8 @@ You can submit pull requests for small changes such as:
 
 If your pull request is a large change such as
 
-* Adding a new feature to Autoware
-* Adding a new page to the documentation
+- Adding a new feature to Autoware
+- Adding a new page to the documentation
 
 discuss with the maintainers before submission. Doing so ensures that the proposed change is in line with Autoware's design philosophy and current development plans. If you're not sure where to have that conversation, then [create a new Q&A discussion](https://github.com/autowarefoundation/autoware/discussions/new?category=q-a).
 


### PR DESCRIPTION
Signed-off-by: IshitaTakeshi <ishitah.takeshi@gmail.com>

## Description

I thought that contributors might be curious that their proposals deserve to open Q&A and pull requests, so I added more concrete example cases

https://github.com/autowarefoundation/autoware/discussions/271

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
