### PR TITLE
ci(deploy-docs): remove mdx_unimoji

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -66,7 +66,6 @@ markdown_extensions:
   - mdx_math
   - mdx_truly_sane_lists:
       nested_indent: 2
-  - mdx_unimoji
   - plantuml_markdown:
       server: http://www.plantuml.com/plantuml
       format: svg


### PR DESCRIPTION
Signed-off-by: Shumpei Wakabayashi <shumpei.wakabayashi@tier4.jp>

## Description
mdx_unimoji is deprecated and it should be deleted since https://github.com/autowarefoundation/autoware-github-actions/issues/145

Related PR
https://github.com/autowarefoundation/autoware-github-actions/pull/146


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
