### PR TITLE
docs: change repo_url to autoware meta repository

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,7 +1,7 @@
 site_name: Autoware Documentation
 site_url: https://autowarefoundation.github.io/autoware-documentation
 repo_url: https://github.com/autowarefoundation/autoware
-edit_uri: edit/main/docs/
+edit_uri: https://github.com/autowarefoundation/autoware-documentation/edit/main/docs/
 docs_dir: docs
 copyright: Copyright &copy; 2022 The Autoware Foundation
 

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -1,6 +1,6 @@
 site_name: Autoware Documentation
 site_url: https://autowarefoundation.github.io/autoware-documentation
-repo_url: https://github.com/autowarefoundation/autoware-documentation
+repo_url: https://github.com/autowarefoundation/autoware
 edit_uri: edit/main/docs/
 docs_dir: docs
 copyright: Copyright &copy; 2022 The Autoware Foundation


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

It might be good that the GitHub link on the top right of the documentation is linked to https://github.com/autowarefoundation/autoware instead of autoware-documentation.
Then, we can guide people to the main repository.

What do you think about it?

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
