### PR TITLE
docs: fix dead link in how-to-guides

### DIFF
--- a/docs/how-to-guides/how-to-integrate-autoware-with-your-vehicle.md
+++ b/docs/how-to-guides/how-to-integrate-autoware-with-your-vehicle.md
@@ -100,7 +100,7 @@ Create `launch/sensing.launch.xml` that launches the interfaces of all the senso
 !!! note
 
     At this point, you are now able to run Autoware's Planning Simulator to do a basic test of your vehicle and sensing packages.
-    To do so, you need to build and install Autoware using your cloned repository. Follow the [steps for either Docker or source installation](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/) (starting from the dependency installation step) and then run the following command:
+    To do so, you need to build and install Autoware using your cloned repository. Follow the [steps for either Docker or source installation](https://autowarefoundation.github.io/autoware-documentation/main/installation/) (starting from the dependency installation step) and then run the following command:
 
     ```bash
     ros2 launch autoware_launch planning_simulator.launch.xml vehicle_model:=YOUR_VEHICLE sensor_kit:=YOUR_SENSOR_KIT map_path:=/PATH/TO/YOUR/MAP


### PR DESCRIPTION
Signed-off-by: Shark Liu <huiyuan.liu@autocore.ai>

## Description

Fix dead link in "How to integrate Autoware with your vehicle" page

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
