### PR TITLE
feat: improve contribution guidelines

### DIFF
--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -83,11 +83,19 @@ You can submit pull requests for small changes such as:
 - Fixing warnings detected by compilers or analysis tools
 - Making small changes to a single package
 
-If your pull request is a large change, discuss with the maintainers before submission. Doing so ensures that the proposed change is in line with Autoware's design philosophy and current development plans. If you're not sure where to have that conversation, then [create a new Q&A discussion](https://github.com/autowarefoundation/autoware/discussions/new?category=q-a).
+For more information on how to submit a good pull request, have a read of the [pull request guidelines](pull-request-guidelines/index.md) and don't forget to review the required [license notations](license.md)!
+
+If your pull request is a large change, the following process should be followed:
+
+1. Create a GitHub Discussion to propose the change. Doing so allows you to get feedback from other members and the Autoware maintainers and to ensure that the proposed change is in line with Autoware's design philosophy and current development plans. If you're not sure where to have that conversation, then [create a new Q&A discussion](https://github.com/autowarefoundation/autoware/discussions/new?category=q-a).
+
+2. Create an Issue following consensus in the discussions
+
+3. Create a Pull Request to implement the changes that references the Issue created in step 2
+
+4. Create documentation for the new addition (if relevant)
 
 Examples of large changes include:
 
 - Adding a new feature to Autoware
 - Adding a new documentation page or section
-
-For more information on how to submit a good pull request, have a read of the [pull request guidelines](pull-request-guidelines/index.md) and don't forget to review the required [license notations](license.md)!


### PR DESCRIPTION
Signed-off-by: Lalith Vipulananthan <lalith.vipulananthan@tier4.jp>

## Description

Improve guidelines for submitting large changes or new features, based on discussion with @BonoloAWF. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
