### PR TITLE
docs(docker): add cmd for missing dependencies

### DIFF
--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -76,7 +76,7 @@ You might need to log out and log back to make the current user able to use dock
    mkdir src
    vcs import src < autoware.repos
    ```
-   
+
 3. Install missing dependencies.
 
    ```bash
@@ -85,7 +85,7 @@ You might need to log out and log back to make the current user able to use dock
    rosdep update
    rosdep install --from-paths . --ignore-src --rosdistro $ROS_DISTRO
    ```
-   
+
 4. Build the workspace.
 
    ```bash

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -79,8 +79,8 @@ You might need to log out and log back to make the current user able to use dock
 
 3. Update dependent ROS packages.
 
-    The dependency of Autoware may change after the Docker image was created.
-    In that case, you need to run the following commands to update the dependency.
+   The dependency of Autoware may change after the Docker image was created.
+   In that case, you need to run the following commands to update the dependency.
 
    ```bash
    sudo apt update

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -76,8 +76,17 @@ You might need to log out and log back to make the current user able to use dock
    mkdir src
    vcs import src < autoware.repos
    ```
+   
+3. Install missing dependencies.
 
-3. Build the workspace.
+   ```bash
+   sudo apt update
+   source /opt/ros/galactic/setup.bash
+   rosdep update
+   rosdep install --from-paths . --ignore-src --rosdistro $ROS_DISTRO
+   ```
+   
+4. Build the workspace.
 
    ```bash
    colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -77,11 +77,13 @@ You might need to log out and log back to make the current user able to use dock
    vcs import src < autoware.repos
    ```
 
-3. Install missing dependencies.
+3. Update dependent ROS packages.
+
+    The dependency of Autoware may change after the Docker image was created.
+    In that case, you need to run the following commands to update the dependency.
 
    ```bash
    sudo apt update
-   source /opt/ros/galactic/setup.bash
    rosdep update
    rosdep install --from-paths . --ignore-src --rosdistro $ROS_DISTRO
    ```


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Following discussions in [this issue](https://github.com/autowarefoundation/autoware/issues/2821), I found that not all dependencies were installed in the docker image.
This PR adds commands to install missing dependencies to the Docker installation instructions.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
