### PR TITLE
feat(support-guidelines): add link to GitHub Docs

### DIFF
--- a/docs/support/support-guidelines.md
+++ b/docs/support/support-guidelines.md
@@ -52,6 +52,8 @@ If your question is not answered within a week, then @mention the maintainers to
 Also, there are other discussion types such as [feature requests](https://github.com/autowarefoundation/autoware/discussions/categories/feature-requests) or [design discussions](https://github.com/autowarefoundation/autoware/discussions/categories/design).
 Feel free to open or join such discussions.
 
+If you don't know how to create a discussion, refert to [here](https://docs.github.com/en/discussions/quickstart#creating-a-new-discussion).
+
 ## GitHub Issues
 
 If you have a problem and you have confirmed it is a bug, find the appropriate repository and create a new issue there.

--- a/docs/support/support-guidelines.md
+++ b/docs/support/support-guidelines.md
@@ -52,7 +52,7 @@ If your question is not answered within a week, then @mention the maintainers to
 Also, there are other discussion types such as [feature requests](https://github.com/autowarefoundation/autoware/discussions/categories/feature-requests) or [design discussions](https://github.com/autowarefoundation/autoware/discussions/categories/design).
 Feel free to open or join such discussions.
 
-If you don't know how to create a discussion, refert to [here](https://docs.github.com/en/discussions/quickstart#creating-a-new-discussion).
+If you don't know how to create a discussion, refer to [GitHub Docs](https://docs.github.com/en/discussions/quickstart#creating-a-new-discussion).
 
 ## GitHub Issues
 


### PR DESCRIPTION
Signed-off-by: Shigekazu Fukuta <shigekazu.fukuta@tier4.jp>

## Description

Add link how to create github discussion in support guideline.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
