### PR TITLE
fix(docker-installation): use -cuda images

### DIFF
--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -51,13 +51,13 @@ You might need to log out and log back to make the current user able to use dock
    - For amd64 architecture computers with NVIDIA GPU:
 
      ```bash
-     rocker --nvidia --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest
+     rocker --nvidia --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest-cuda
      ```
 
    - If you want to run container without using NVIDIA GPU, or for arm64 architecture computers:
 
      ```bash
-     rocker -e LIBGL_ALWAYS_SOFTWARE=1 --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest
+     rocker -e LIBGL_ALWAYS_SOFTWARE=1 --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest-cuda
      ```
 
      For detailed reason could be found [here](#docker-with-nvidia-gpu-fails-to-start-autoware-on-arm64-devices)
@@ -99,7 +99,7 @@ You might need to log out and log back to make the current user able to use dock
 1. Update the Docker image.
 
    ```bash
-   docker pull ghcr.io/autowarefoundation/autoware-universe:latest
+   docker pull ghcr.io/autowarefoundation/autoware-universe:latest-cuda
    ```
 
 2. Launch a Docker container.
@@ -107,13 +107,13 @@ You might need to log out and log back to make the current user able to use dock
    - For amd64 architecture computers:
 
      ```bash
-     rocker --nvidia --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest
+     rocker --nvidia --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest-cuda
      ```
 
    - If you want to run container without using NVIDIA GPU, or for arm64 architecture computers:
 
      ```bash
-     rocker -e LIBGL_ALWAYS_SOFTWARE=1 --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest
+     rocker -e LIBGL_ALWAYS_SOFTWARE=1 --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest-cuda
      ```
 
 3. Update the `.repos` file.
@@ -158,7 +158,7 @@ To fix this, restart your system after installing the new NVIDIA driver.
 When starting Docker with GPU support enabled for NVIDIA graphics on arm64 devices, e.g. NVIDIA jetson AGX xavier, you may receive the following error:
 
 ```bash
-nvidia@xavier:~$ rocker --nvidia --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest-arm64
+nvidia@xavier:~$ rocker --nvidia --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:galactic-latest-cuda-arm64
 ...
 
 Collecting staticx==0.12.3
@@ -181,7 +181,7 @@ To fix this error, temporary modification of rocker source code is required, whi
 At current stage, it is recommended to run docker without NVIDIA gpu enabled for arm64 devices:
 
 ```bash
-rocker -e LIBGL_ALWAYS_SOFTWARE=1 --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest
+rocker -e LIBGL_ALWAYS_SOFTWARE=1 --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest-cuda
 ```
 
 This tutorial will be updated after official fix from rocker.
@@ -214,7 +214,7 @@ aarch64
 To run Autoware's Docker images of `arm64` architecture, add the suffix `-arm64`.
 
 ```sh-session
-$ docker run --rm -it ghcr.io/autowarefoundation/autoware-universe:latest-arm64
+$ docker run --rm -it ghcr.io/autowarefoundation/autoware-universe:galactic-latest-cuda-arm64
 WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64) and no specific platform was requested
 root@5b71391ad50f:/autoware#
 ```


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

The `latest` image doesn't contain `CUDA` after https://github.com/autowarefoundation/autoware_core_universe_prototype/pull/346, which may cause some errors in the tutorial.

Related: https://github.com/autowarefoundation/autoware/issues/2821

Please refer to https://github.com/autowarefoundation/autoware/pkgs/container/autoware-universe/versions for all tags.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
