### PR TITLE
fix(tutorial): add -y for rosdep and fix markdown link

### DIFF
--- a/docs/tutorials/scenario-simulation/planning-simulation/installation.md
+++ b/docs/tutorials/scenario-simulation/planning-simulation/installation.md
@@ -24,7 +24,7 @@ This document contains step-by-step instruction on how to build [AWF Autoware Co
 
    ```bash
    source /opt/ros/galactic/setup.bash
-   rosdep install --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+   rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
    ```
 
 4. Build the workspace:

--- a/docs/tutorials/scenario-simulation/planning-simulation/random-test-simulation.md
+++ b/docs/tutorials/scenario-simulation/planning-simulation/random-test-simulation.md
@@ -25,4 +25,4 @@
 
 ![random_test_runner](images/random_test_runner.png)
 
-For more information about supported parameters, refer to the ![random_test_runner documentation].(<https://github.com/tier4/scenario_simulator_v2/blob/master/docs/user_guide/random_test_runner/README.md#node-parameters>)
+For more information about supported parameters, refer to the [random_test_runner documentation](https://github.com/tier4/scenario_simulator_v2/blob/master/docs/user_guide/random_test_runner/README.md#node-parameters).


### PR DESCRIPTION
## Description

Add -y to `rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO`,
which is in the installation of Scenario simulation tutorial.

This can avoid too many annoying installation checkings.

Also fix the markdown link in [the tutorial](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/scenario-simulation/planning-simulation/random-test-simulation/#running-steps).

![image](https://user-images.githubusercontent.com/456210/191212097-91954440-9cd7-4467-9f62-c41c164a9b04.png)


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
