### PR TITLE
fix(tutorials): use gdown to download files from Google Drive

### DIFF
--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -53,24 +53,30 @@ You might need to log out and log back to make the current user able to use dock
     Before proceeding, confirm and agree with the [NVIDIA Deep Learning Container license](https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license).
     By pulling and using the Autoware Universe images, you accept the terms and conditions of the license.
 
-1. Launch a Docker container.
+1. Create the `autoware_map` directory for map data later.
+
+   ```bash
+   mkdir ~/autoware_map
+   ```
+
+2. Launch a Docker container.
 
    - For amd64 architecture computers with NVIDIA GPU:
 
      ```bash
-     rocker --nvidia --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest-cuda
+     rocker --nvidia --x11 --user --volume $HOME/autoware --volume $HOME/autoware_map -- ghcr.io/autowarefoundation/autoware-universe:latest-cuda
      ```
 
    - If you want to use ROS 2 Humble:
 
      ```bash
-     rocker --nvidia --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:humble-latest-cuda
+     rocker --nvidia --x11 --user --volume $HOME/autoware --volume $HOME/autoware_map -- ghcr.io/autowarefoundation/autoware-universe:humble-latest-cuda
      ```
 
    - If you want to run container without using NVIDIA GPU, or for arm64 architecture computers:
 
      ```bash
-     rocker -e LIBGL_ALWAYS_SOFTWARE=1 --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:latest-cuda
+     rocker -e LIBGL_ALWAYS_SOFTWARE=1 --x11 --user --volume $HOME/autoware --volume $HOME/autoware_map -- ghcr.io/autowarefoundation/autoware-universe:latest-cuda
      ```
 
      For detailed reason could be found [here](#docker-with-nvidia-gpu-fails-to-start-autoware-on-arm64-devices)
@@ -83,14 +89,14 @@ You might need to log out and log back to make the current user able to use dock
    cd autoware
    ```
 
-2. Create the `src` directory and clone repositories into it.
+3. Create the `src` directory and clone repositories into it.
 
    ```bash
    mkdir src
    vcs import src < autoware.repos
    ```
 
-3. Update dependent ROS packages.
+4. Update dependent ROS packages.
 
    The dependency of Autoware may change after the Docker image was created.
    In that case, you need to run the following commands to update the dependency.
@@ -101,7 +107,7 @@ You might need to log out and log back to make the current user able to use dock
    rosdep install --from-paths . --ignore-src --rosdistro $ROS_DISTRO
    ```
 
-4. Build the workspace.
+5. Build the workspace.
 
    ```bash
    colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release

--- a/docs/tutorials/ad-hoc-simulation/planning-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/planning-simulation.md
@@ -4,11 +4,11 @@
 
 Download and unpack a sample map.
 
-- Click [here](https://drive.google.com/file/d/1499_nsbUbIeturZaDj7jhUownh5fvXHd/view?usp=sharing) to download.
-- Unpack it by running the following command.
+- You can also download [the map](https://drive.google.com/file/d/1499_nsbUbIeturZaDj7jhUownh5fvXHd/view?usp=sharing) manually.
 
 ```bash
-unzip -d ~/Downloads/ ~/Downloads/sample-map-planning.zip
+wget -O ~/autoware/sample-map-planning.zip 'https://docs.google.com/uc?export=download&id=1499_nsbUbIeturZaDj7jhUownh5fvXHd'
+unzip -d ~/autoware ~/autoware/sample-map-planning.zip
 ```
 
 !!! Note
@@ -23,7 +23,7 @@ unzip -d ~/Downloads/ ~/Downloads/sample-map-planning.zip
 
 ```bash
 source ~/autoware/install/setup.bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/Downloads/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
 ```
 
 !!! warning

--- a/docs/tutorials/ad-hoc-simulation/planning-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/planning-simulation.md
@@ -7,8 +7,8 @@ Download and unpack a sample map.
 - You can also download [the map](https://drive.google.com/file/d/1499_nsbUbIeturZaDj7jhUownh5fvXHd/view?usp=sharing) manually.
 
 ```bash
-wget -O ~/autoware/sample-map-planning.zip 'https://docs.google.com/uc?export=download&id=1499_nsbUbIeturZaDj7jhUownh5fvXHd'
-unzip -d ~/autoware ~/autoware/sample-map-planning.zip
+gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=1499_nsbUbIeturZaDj7jhUownh5fvXHd'
+unzip -d ~/autoware_map ~/autoware_map/sample-map-planning.zip
 ```
 
 !!! Note
@@ -23,7 +23,7 @@ unzip -d ~/autoware ~/autoware/sample-map-planning.zip
 
 ```bash
 source ~/autoware/install/setup.bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
 ```
 
 !!! warning

--- a/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
@@ -4,20 +4,22 @@
 
 1. Download and unpack a sample map.
 
-   - Click [here](https://drive.google.com/file/d/1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI/view?usp=sharing) to download.
-   - Unpack it by running the following command.
+   - You can also download [the map](https://drive.google.com/file/d/1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI/view?usp=sharing) manually.
 
    ```bash
-   unzip -d ~/Downloads/ ~/Downloads/sample-map-rosbag.zip
+   wget -O ~/autoware/sample-map-rosbag.zip 'https://docs.google.com/uc?export=download&id=1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI'
+   unzip -d ~/autoware/ ~/autoware/sample-map-rosbag.zip
    ```
 
 2. Download the sample rosbag files.
 
-   - Click [here](https://drive.google.com/file/d/1VnwJx9tI3kI_cTLzP61ktuAJ1ChgygpG/view?usp=sharing) to download.
-   - Unpack it by running the following command.
+   - You can also download [the rosbag files](https://drive.google.com/file/d/1VnwJx9tI3kI_cTLzP61ktuAJ1ChgygpG/view?usp=sharing) manually.
 
    ```bash
-   unzip -d ~/Downloads/ ~/Downloads/sample-rosbag.zip
+   # The file exceeds 100 MB and we need to confirm before downloading
+   wget --save-cookies /tmp/cookies.txt 'https://docs.google.com/uc?export=download&id=1VnwJx9tI3kI_cTLzP61ktuAJ1ChgygpG' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1/p' > /tmp/confirm.txt
+   wget --load-cookies /tmp/cookies.txt -O ~/autoware/sample-rosbag.zip 'https://docs.google.com/uc?export=download&id=1VnwJx9tI3kI_cTLzP61ktuAJ1ChgygpG&confirm='$(</tmp/confirm.txt)
+   unzip -d ~/autoware/ ~/autoware/sample-rosbag.zip
    ```
 
 ### Note
@@ -33,7 +35,7 @@
 
    ```sh
    source ~/autoware/install/setup.bash
-   ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/Downloads/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+   ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
    ```
 
    Note that you cannot use `~` instead of `$HOME` here.
@@ -44,7 +46,7 @@
 
    ```sh
    source ~/autoware/install/setup.bash
-   ros2 bag play ~/Downloads/sample-rosbag/sample.db3 -r 0.2
+   ros2 bag play ~/autoware/sample-rosbag/sample.db3 -r 0.2
    ```
 
    ![after-rosbag-play](images/rosbag-replay/after-rosbag-play.png)

--- a/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
@@ -7,8 +7,8 @@
    - You can also download [the map](https://drive.google.com/file/d/1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI/view?usp=sharing) manually.
 
    ```bash
-   wget -O ~/autoware/sample-map-rosbag.zip 'https://docs.google.com/uc?export=download&id=1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI'
-   unzip -d ~/autoware/ ~/autoware/sample-map-rosbag.zip
+   gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI'
+   unzip -d ~/autoware_map/ ~/autoware_map/sample-map-rosbag.zip
    ```
 
 2. Download the sample rosbag files.
@@ -16,10 +16,8 @@
    - You can also download [the rosbag files](https://drive.google.com/file/d/1VnwJx9tI3kI_cTLzP61ktuAJ1ChgygpG/view?usp=sharing) manually.
 
    ```bash
-   # The file exceeds 100 MB and we need to confirm before downloading
-   wget --save-cookies /tmp/cookies.txt 'https://docs.google.com/uc?export=download&id=1VnwJx9tI3kI_cTLzP61ktuAJ1ChgygpG' -O- | sed -rn 's/.*confirm=([0-9A-Za-z_]+).*/\1/p' > /tmp/confirm.txt
-   wget --load-cookies /tmp/cookies.txt -O ~/autoware/sample-rosbag.zip 'https://docs.google.com/uc?export=download&id=1VnwJx9tI3kI_cTLzP61ktuAJ1ChgygpG&confirm='$(</tmp/confirm.txt)
-   unzip -d ~/autoware/ ~/autoware/sample-rosbag.zip
+   gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=1VnwJx9tI3kI_cTLzP61ktuAJ1ChgygpG'
+   unzip -d ~/autoware_map/ ~/autoware_map/sample-rosbag.zip
    ```
 
 ### Note
@@ -35,7 +33,7 @@
 
    ```sh
    source ~/autoware/install/setup.bash
-   ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+   ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
    ```
 
    Note that you cannot use `~` instead of `$HOME` here.
@@ -46,7 +44,7 @@
 
    ```sh
    source ~/autoware/install/setup.bash
-   ros2 bag play ~/autoware/sample-rosbag/sample.db3 -r 0.2
+   ros2 bag play ~/autoware_map/sample-rosbag/sample.db3 -r 0.2
    ```
 
    ![after-rosbag-play](images/rosbag-replay/after-rosbag-play.png)


### PR DESCRIPTION
## Description

While trying [examples](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/) in docker containers, it's inconvenience to download files directly from Google Drive. Besides, there is no `Downloads` folder in docker container, so users should modify the path by themselves. Suggest to use `wget` instead.

Refer to [here](https://www.matthuisman.nz/2019/01/download-google-drive-files-wget-curl.html) for how to download files from Google Drive with wget.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
