### PR TITLE
fix(design/autoware-interfaces): fix the link of ResponseStatus

### DIFF
--- a/docs/design/autoware-interfaces/index.md
+++ b/docs/design/autoware-interfaces/index.md
@@ -162,7 +162,7 @@ Currently, there is no required header.
 
 The interfaces whose communication method is Function Call use a common response status to unify the error format.
 These interfaces should include a variable of ResponseStatus with the name status in the response.
-See [autoware_ad_api_msgs/msg/ResponseStatus](https://github.com/autowarefoundation/autoware.universe/blob/main/common/autoware_ad_api_msgs/README.md#responsestatus) for details.
+See [autoware_adapi_v1_msgs/msg/ResponseStatus](https://github.com/autowarefoundation/autoware_adapi_msgs/tree/main/autoware_adapi_v1_msgs#responsestatus) for details.
 
 ## Concerns, assumptions and limitations
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

The package has been moved and renamed.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
