### PR TITLE
docs(installation): add troubleshooting link to installation

### DIFF
--- a/docs/design/autoware-interfaces/components/control.md
+++ b/docs/design/autoware-interfaces/components/control.md
@@ -43,7 +43,7 @@ TODO This represents the reported physical efforts exerted by the vehicle actuat
 
 A motion signal to drive the vehicle, achieved by the low-level controller in the vehicle layer. Used by the Vehicle Interface.
 
-- [autoware_auto_control_msgs/AckermannControlCommand](<https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/blob/master/autoware_auto_control_msgs/msg/AckermannControlCommand.idl>
+- [autoware_auto_control_msgs/AckermannControlCommand](https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/blob/master/autoware_auto_control_msgs/msg/AckermannControlCommand.idl)
   - builtin_interfaces::msg::Time stamp
   - [autoware_auto_control_msgs/AckermannLateralCommand](https://gitlab.com/autowarefoundation/autoware.auto/autoware_auto_msgs/-/blob/master/autoware_auto_control_msgs/msg/AckermannLateralCommand.idl) lateral
     - builtin_interfaces::msg::Time stamp

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -104,7 +104,7 @@ You might need to log out and log back to make the current user able to use dock
    ```bash
    sudo apt update
    rosdep update
-   rosdep install --from-paths . --ignore-src --rosdistro $ROS_DISTRO
+   rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
    ```
 
 5. Build the workspace.
@@ -112,6 +112,8 @@ You might need to log out and log back to make the current user able to use dock
    ```bash
    colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
    ```
+
+   If there is any build issue, refer to [Troubleshooting](https://autowarefoundation.github.io/autoware-documentation/main/support/troubleshooting/#build-issues).
 
 ## How to update a workspace
 

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -100,6 +100,8 @@ If you've manually installed the dependencies, you can skip this section.
    colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
    ```
 
+   If there is any build issue, refer to [Troubleshooting](https://autowarefoundation.github.io/autoware-documentation/main/support/troubleshooting/#build-issues).
+
 ## How to update a workspace
 
 1. Update the `.repos` file.

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -79,6 +79,15 @@ free -h
 
 For more detailed configuration steps, along with an explanation of swap, refer to Digital Ocean's ["How To Add Swap Space on Ubuntu 20.04" tutorial](https://www.digitalocean.com/community/tutorials/how-to-add-swap-space-on-ubuntu-20-04)
 
+If there are too many CPU cores (more than 64) in your machine, it might requires larger memory.
+A workaround here is to limit the job number while building.
+
+```bash
+MAKEFLAGS="-j4" colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
+```
+
+You can adjust `-j4` to any number based on your system.
+
 ### Errors when using the latest version of Autoware
 
 If you are working with the latest version of Autoware, issues can occur due to out-of-date software or old build files.


### PR DESCRIPTION
## Description

The PR includes the following:

1. Add "how to limit build job" while there are too many CPU cores.
   - This is the problem I met [here](https://github.com/autowarefoundation/autoware/discussions/2901)
2. Add troubleshooting link in installation pages.
   - Troubleshooting page is a little hard to find. While build error, I don't know there is "build issue" section in troubleshooting page.
3. Fix markdown link.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
