### PR TITLE
chore: support emoji for mkdocs.

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -62,6 +62,9 @@ markdown_extensions:
   - attr_list
   - codehilite:
       guess_lang: false
+  - pymdownx.emoji:
+      emoji_index: !!python/name:materialx.emoji.twemoji
+      emoji_generator: !!python/name:materialx.emoji.to_svg
   - fontawesome_markdown
   - footnotes
   - mdx_math


### PR DESCRIPTION
## Description

As described [here](https://github.com/autowarefoundation/open-ad-kit-docs/pull/34#issuecomment-1264212294), add markdown_extensions to support emoji in mkdocs.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
