### PR TITLE
docs(planning): add limitation of path points size

### DIFF
--- a/docs/design/autoware-architecture/planning/index.md
+++ b/docs/design/autoware-architecture/planning/index.md
@@ -85,7 +85,9 @@ For more details, please refer to the design documents in each package.
 
 ## Notation
 
-[1] To support the self-crossing road and overlapped road in the opposite direction, each planning module has to meet the [specifications](https://autowarefoundation.github.io/autoware.universe/main/common/motion_utils/)
+### [1] self-crossing road and overlapped
+
+To support the self-crossing road and overlapped road in the opposite direction, each planning module has to meet the [specifications](https://autowarefoundation.github.io/autoware.universe/main/common/motion_utils/)
 
 Currently, the supported modules are as follows.
 
@@ -96,3 +98,7 @@ Currently, the supported modules are as follows.
 - obstacle_avoidance_planner
 - obstacle_stop_planner
 - motion_velocity_smoother
+
+#### [2] Size of Path Points
+
+Some functions do not support paths with only one point. Therefore, each modules should generate the path with more than two path points.


### PR DESCRIPTION
Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->

Some modules and functions do not support paths with only one point, so add it to the limitations of docs.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
