### PR TITLE
fix(docs): update documentation for humble from galactic

### DIFF
--- a/docs/contributing/coding-guidelines/ros-nodes/message-guidelines.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/message-guidelines.md
@@ -2,7 +2,7 @@
 
 ## Format
 
-All messages should follow [ROS message description specification](https://docs.ros.org/en/galactic/Concepts/About-ROS-Interfaces.html#background).
+All messages should follow [ROS message description specification](https://docs.ros.org/en/humble/Concepts/About-ROS-Interfaces.html#background).
 
 The accepted formats are:
 
@@ -53,7 +53,7 @@ For non-default units, use following suffixes:
 
 ## Message field types
 
-For list of types supported by the ROS interfaces [see here](https://docs.ros.org/en/galactic/Concepts/About-ROS-Interfaces.html#field-types).
+For list of types supported by the ROS interfaces [see here](https://docs.ros.org/en/humble/Concepts/About-ROS-Interfaces.html#field-types).
 
 Also copied here for convenience:
 

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -19,13 +19,6 @@
    cd autoware
    ```
 
-   If you want to use ROS 2 Humble, use the `humble` branch.
-
-   ```bash
-   git clone https://github.com/autowarefoundation/autoware.git -b humble
-   cd autoware
-   ```
-
 2. You can install the dependencies either manually or using the provided Ansible script.
 
 > Note: Before installing NVIDIA libraries, confirm and agree with the licenses.
@@ -70,12 +63,6 @@ You might need to log out and log back to make the current user able to use dock
 
      ```bash
      rocker --nvidia --x11 --user --volume $HOME/autoware --volume $HOME/autoware_map -- ghcr.io/autowarefoundation/autoware-universe:latest-cuda
-     ```
-
-   - If you want to use ROS 2 Humble:
-
-     ```bash
-     rocker --nvidia --x11 --user --volume $HOME/autoware --volume $HOME/autoware_map -- ghcr.io/autowarefoundation/autoware-universe:humble-latest-cuda
      ```
 
    - If you want to run container without using NVIDIA GPU, or for arm64 architecture computers:
@@ -184,7 +171,7 @@ To fix this, restart your system after installing the new NVIDIA driver.
 When starting Docker with GPU support enabled for NVIDIA graphics on arm64 devices, e.g. NVIDIA jetson AGX xavier, you may receive the following error:
 
 ```bash
-nvidia@xavier:~$ rocker --nvidia --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:galactic-latest-cuda-arm64
+nvidia@xavier:~$ rocker --nvidia --x11 --user --volume $HOME/autoware -- ghcr.io/autowarefoundation/autoware-universe:humble-latest-cuda-arm64
 ...
 
 Collecting staticx==0.12.3
@@ -240,7 +227,7 @@ aarch64
 To run Autoware's Docker images of `arm64` architecture, add the suffix `-arm64`.
 
 ```sh-session
-$ docker run --rm -it ghcr.io/autowarefoundation/autoware-universe:galactic-latest-cuda-arm64
+$ docker run --rm -it ghcr.io/autowarefoundation/autoware-universe:humble-latest-cuda-arm64
 WARNING: The requested image's platform (linux/arm64) does not match the detected host platform (linux/amd64) and no specific platform was requested
 root@5b71391ad50f:/autoware#
 ```

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -4,12 +4,10 @@
 
 - OS
 
-  - [Ubuntu 20.04](https://releases.ubuntu.com/20.04/)
   - [Ubuntu 22.04](https://releases.ubuntu.com/22.04/)
 
 - ROS
 
-  - ROS 2 Galactic
   - ROS 2 Humble
 
   For ROS 2 system dependencies, refer to [REP-2000](https://www.ros.org/reps/rep-2000.html).
@@ -22,19 +20,14 @@ sudo apt-get -y update
 sudo apt-get -y install git
 ```
 
+> Note: If you wish to use ROS 2 Galactic on Ubuntu 20.04, refer to installation instruction from [galactic](https://autowarefoundation.github.io/autoware-documentation/galactic/installation/autoware/source-installation/) branch, but be aware that Galactic version of Autoware might not have latest features.
+
 ## How to set up a development environment
 
 1. Clone `autowarefoundation/autoware` and move to the directory.
 
    ```bash
    git clone https://github.com/autowarefoundation/autoware.git
-   cd autoware
-   ```
-
-   If you want to use ROS 2 Humble, use the `humble` branch.
-
-   ```bash
-   git clone https://github.com/autowarefoundation/autoware.git -b humble
    cd autoware
    ```
 
@@ -87,7 +80,7 @@ If you've manually installed the dependencies, you can skip this section.
    You might need to run `rosdep update` before `rosdep install`.
 
    ```bash
-   source /opt/ros/galactic/setup.bash
+   source /opt/ros/humble/setup.bash
    rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
    ```
 
@@ -130,7 +123,7 @@ If you've manually installed the dependencies, you can skip this section.
 3. Install dependent ROS packages.
 
    ```bash
-   source /opt/ros/galactic/setup.bash
+   source /opt/ros/humble/setup.bash
    rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
    ```
 

--- a/docs/tutorials/scenario-simulation/planning-simulation/installation.md
+++ b/docs/tutorials/scenario-simulation/planning-simulation/installation.md
@@ -23,7 +23,7 @@ This document contains step-by-step instruction on how to build [AWF Autoware Co
 3. Install dependent ROS packages:
 
    ```bash
-   source /opt/ros/galactic/setup.bash
+   source /opt/ros/humble/setup.bash
    rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
    ```
 


### PR DESCRIPTION
Signed-off-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>

## Description
We are transitioning to ROS 2 Humble, and we no longer guarantee building on Galactic.
This PR would remove galactic related instruction.

Related Issue/Discussions/PRs:
https://github.com/orgs/autowarefoundation/discussions/2622
https://github.com/autowarefoundation/autoware/issues/3083

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
