### PR TITLE
fix(docs): fix source installation instruction to use galactic branch

### DIFF
--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -5,12 +5,10 @@
 - OS
 
   - [Ubuntu 20.04](https://releases.ubuntu.com/20.04/)
-  - [Ubuntu 22.04](https://releases.ubuntu.com/22.04/)
 
 - ROS
 
   - ROS 2 Galactic
-  - ROS 2 Humble
 
   For ROS 2 system dependencies, refer to [REP-2000](https://www.ros.org/reps/rep-2000.html).
 
@@ -27,14 +25,7 @@ sudo apt-get -y install git
 1. Clone `autowarefoundation/autoware` and move to the directory.
 
    ```bash
-   git clone https://github.com/autowarefoundation/autoware.git
-   cd autoware
-   ```
-
-   If you want to use ROS 2 Humble, use the `humble` branch.
-
-   ```bash
-   git clone https://github.com/autowarefoundation/autoware.git -b humble
+   git clone https://github.com/autowarefoundation/autoware.git -b galactic
    cd autoware
    ```
 


### PR DESCRIPTION
Signed-off-by: mitsudome-r <ryohsuke.mitsudome@tier4.jp>

## Description
As we are switching to ROS 2 Humble in the main branch of Autoware, we should modify the instruction to use specify galactic branch if people wish to use galactic.

https://github.com/autowarefoundation/autoware/issues/3083

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
