### PR TITLE
fix: titles in ADAPI and state on Routing

### DIFF
--- a/docs/design/autoware-interfaces/ad-api/list/api/localization/index.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/localization/index.md
@@ -1,4 +1,4 @@
-# Pose API
+# Localization API
 
 - {{ link_ad_api('/api/localization/initialization_state') }}
 - {{ link_ad_api('/api/localization/initialize') }}

--- a/docs/design/autoware-interfaces/ad-api/list/api/motion/index.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/motion/index.md
@@ -1,4 +1,4 @@
-# Planning API
+# Motion API
 
 - {{ link_ad_api('/api/motion/state') }}
 - {{ link_ad_api('/api/motion/accept_start') }}

--- a/docs/design/autoware-interfaces/ad-api/list/api/operation_mode/index.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/operation_mode/index.md
@@ -1,4 +1,4 @@
-# Operation Mode
+# Operation Mode API
 
 - {{ link_ad_api('/api/operation_mode/state') }}
 - {{ link_ad_api('/api/operation_mode/change_to_autonomous') }}

--- a/docs/design/autoware-interfaces/ad-api/list/api/routing/index.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/routing/index.md
@@ -18,7 +18,7 @@ There are two ways to set the route. The one is a generic method that uses pose,
 
 | State    | Description                                        |
 | -------- | -------------------------------------------------- |
-| WAITING  | The route is not set. Waiting for a route request. |
+| UNSET    | The route is not set. Waiting for a route request. |
 | SET      | The route is set.                                  |
 | ARRIVED  | The vehicle has arrived at the destination.        |
 | CHANGING | Trying to change the route. Not implemented yet.   |


### PR DESCRIPTION
Signed-off-by: h-ohta <hiroki.ota@tier4.jp>

## Description

- fix titles in ADAPI
- fix state WAITING -> UNSET on Routing

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
