### PR TITLE
fix(dead-link): update dead autosar link

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -9,6 +9,9 @@
     },
     {
       "pattern": "^https://github.com/.*/discussions/new"
+    },
+    {
+      "pattern": "^https://www\\.autosar\\.org/*"
     }
   ],
   "retryOn429": true,

--- a/docs/contributing/coding-guidelines/languages/cpp.md
+++ b/docs/contributing/coding-guidelines/languages/cpp.md
@@ -9,7 +9,7 @@
 Follow the guidelines below if a rule is not defined on this page.
 
 1. <https://docs.ros.org/en/humble/Contributing/Code-Style-Language-Versions.html>
-2. <https://www.autosar.org/fileadmin/user_upload/standards/adaptive/21-11/AUTOSAR_RS_CPP14Guidelines.pdf>
+2. <https://www.autosar.org/fileadmin/standards/adaptive/18-03/AUTOSAR_RS_CPP14Guidelines.pdf>
 3. <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines>
 
 Also, it is encouraged to apply Clang-Tidy to each file.

--- a/docs/contributing/coding-guidelines/languages/cpp.md
+++ b/docs/contributing/coding-guidelines/languages/cpp.md
@@ -9,7 +9,7 @@
 Follow the guidelines below if a rule is not defined on this page.
 
 1. <https://docs.ros.org/en/humble/Contributing/Code-Style-Language-Versions.html>
-2. <https://www.autosar.org/fileadmin/standards/adaptive/18-03/AUTOSAR_RS_CPP14Guidelines.pdf>
+2. <https://www.autosar.org/fileadmin/standards/adaptive/22-11/AUTOSAR_RS_CPP14Guidelines.pdf>
 3. <https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines>
 
 Also, it is encouraged to apply Clang-Tidy to each file.


### PR DESCRIPTION
Signed-off-by: M. Fatih Cırıt <mfc@leodrive.ai>

## Description

Fixes failing pre-commit-optional ci: https://github.com/autowarefoundation/autoware-documentation/actions/runs/3767529962/jobs/6405151006

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
