### PR TITLE
docs(message-guidelines): add plural type naming

### DIFF
--- a/docs/contributing/coding-guidelines/ros-nodes/message-guidelines.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/message-guidelines.md
@@ -16,7 +16,7 @@ The accepted formats are:
 
     Under Construction
 
-Use `Array` as a suffix when creating a plural type of a message. This suffix is standardly used in [common_interfaces](https://github.com/ros2/common_interfaces).
+Use `Array` as a suffix when creating a plural type of a message. This suffix is commonly used in [common_interfaces](https://github.com/ros2/common_interfaces).
 
 ## Default units
 

--- a/docs/contributing/coding-guidelines/ros-nodes/message-guidelines.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/message-guidelines.md
@@ -10,6 +10,14 @@ The accepted formats are:
 - `.srv`
 - `.action`
 
+## Naming
+
+!!! warning ""
+
+    Under Construction
+
+Use `Array` as a suffix when creating a plural type of a message. This suffix is standardly used in [common_interfaces](https://github.com/ros2/common_interfaces).
+
 ## Default units
 
 All the fields by default have the following units depending on their types:


### PR DESCRIPTION
Signed-off-by: Takagi, Isamu <isamu.takagi@tier4.jp>

## Description

Add plural type naming to message guidelines. See https://github.com/autowarefoundation/autoware-documentation/issues/296 for details.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
