### PR TITLE
feat: add navigation.footer

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -15,6 +15,7 @@ theme:
     - navigation.tabs
     - navigation.tabs.sticky
     - navigation.top
+    - navigation.footer
   favicon: assets/images/autoware-foundation.png
   icon:
     logo: fontawesome/solid/car


### PR DESCRIPTION
## Description

The footer navigation is gone.
![mkdocs_footter](https://user-images.githubusercontent.com/16977736/215686634-28304c0a-58ab-4f50-b14a-627c008b39b4.png)

The major version of mkdocs material has been upgraded and a new configuration item has been added.
https://squidfunk.github.io/mkdocs-material/setup/setting-up-the-footer/#navigation

This PR will enable the above settings and behave the same as before

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
