### PR TITLE
docs(how-to-guides): deploy different neural network models from Pytorch hub inside traffic_light_classifier node

### DIFF
--- a/docs/how-to-guides/.pages
+++ b/docs/how-to-guides/.pages
@@ -11,3 +11,4 @@ nav:
   - debug-autoware.md
   - add-a-custom-ros-message.md
   - fixing-dependent-package-versions.md
+  - traffic-light-classifier-node-training.md

--- a/docs/how-to-guides/.pages
+++ b/docs/how-to-guides/.pages
@@ -11,4 +11,4 @@ nav:
   - debug-autoware.md
   - add-a-custom-ros-message.md
   - fixing-dependent-package-versions.md
-  - traffic-light-classifier-node-training.md
+  - traffic-light-classifier-node-different-model-testing.md

--- a/docs/how-to-guides/index.md
+++ b/docs/how-to-guides/index.md
@@ -12,7 +12,7 @@
 - [Debug Autoware](debug-autoware.md)
 - [Add a custom ROS message](add-a-custom-ros-message.md)
 - [Fixing dependent package versions](fixing-dependent-package-versions.md)
-- [Train different neural network inside traffic light classifier node](traffic-light-classifier-node-training.md)
+- [Testing different neural network models inside traffic light classifier node](traffic-light-classifier-node-different-model-testing.md)
 
 TODO: Write the following contents.
 

--- a/docs/how-to-guides/index.md
+++ b/docs/how-to-guides/index.md
@@ -12,6 +12,7 @@
 - [Debug Autoware](debug-autoware.md)
 - [Add a custom ROS message](add-a-custom-ros-message.md)
 - [Fixing dependent package versions](fixing-dependent-package-versions.md)
+- [Train different neural network inside traffic light classifier node](traffic-light-classifier-node-training.md)
 
 TODO: Write the following contents.
 

--- a/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
+++ b/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
@@ -1,10 +1,11 @@
 # How to Deploy Different Neural Network Models from Pytorch Hub inside Traffic Light Classifier Node
-Currently in Autoware ,we can re-train compatible models as base  from Pytorch hub and use it in traffic_light_classifier node. Here is a tutorial link for training <https://pytorch.org/tutorials/advanced/super_resolution_with_onnxruntime.html>. 
+
+Currently in Autoware ,we can re-train compatible models as base from Pytorch hub and use it in traffic_light_classifier node. Here is a tutorial link for training <https://pytorch.org/tutorials/advanced/super_resolution_with_onnxruntime.html>.
 This guide explains which neural network models are trained and tested in the traffic light classifier node and for future developments it can help about replace current model to another model without changing TensorRT layers.
 
-After creating custom dataset, you can download default pretrained models. If you want to train without pretrained weights, you can use `pretrained=False`  option when use `torchvision`models.
+After creating custom dataset, you can download default pretrained models. If you want to train without pretrained weights, you can use `pretrained=False` option when use `torchvision`models.
 
-All models in referenced link are  trained and converted the `onnx` format. Here is a link for this onnx conversion <https://deci.ai/blog/how-to-convert-a-pytorch-model-to-onnx/>.
+All models in referenced link are trained and converted the `onnx` format. Here is a link for this onnx conversion <https://deci.ai/blog/how-to-convert-a-pytorch-model-to-onnx/>.
 After that trained models tested on the `traffic_light_classifier` node and here is link for which models are used <https://pytorch.org/vision/0.8/models.html>.
 
 Requirements for the tested models are below:
@@ -22,6 +23,4 @@ Currently, the traffic light classifier node supports the following models with 
 - `ShuffleNet v2`
 - `SqueezeNet`
 
-
-
-These models are supported by TensorRT and can be converted  to `onnx` and `trt engine` files. Then they can be use directly in the `traffic_light_classifier` node.
+These models are supported by TensorRT and can be converted to `onnx` and `trt engine` files. Then they can be use directly in the `traffic_light_classifier` node.

--- a/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
+++ b/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
@@ -19,7 +19,6 @@ Currently, the traffic light classifier node supports the following models with 
 - `GoogLeNet`
 - `MobileNet v2`
 - `ResNet`
-- `ResNeXt`
 - `ShuffleNet v2`
 - `SqueezeNet`
 

--- a/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
+++ b/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
@@ -24,4 +24,4 @@ Currently, the traffic light classifier node supports the following models with 
 
 
 
-These models are supported by TensorRT and can be converted  to `onnx` and `trt engine` files. Then they can be used directly in the `traffic_light_classifier` node.
+These models are supported by TensorRT and can be converted  to `onnx` and `trt engine` files. Then they can be use directly in the `traffic_light_classifier` node.

--- a/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
+++ b/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
@@ -1,7 +1,27 @@
-# How to Train Different Neural Network Models from Pytorch Hub inside Traffic Light Classifier Node
+# How to Test Different Neural Network Models from Pytorch Hub inside Traffic Light Classifier Node
 
-Currently in Autoware , the traffic light classifier node uses  pre-trained MobileNet V2 neural network model from Pytorch Hub. Also you can train a new neural network model using the Pytorch Hub model as a base model. This guide explains how to train a new neural network model and use it in the traffic light classifier node.
+Currently in Autoware ,we can re-train compatible models as base  from Pytorch hub and use it in traffic_light_classifier node. Here is a tutorial link for training <https://pytorch.org/tutorials/advanced/super_resolution_with_onnxruntime.html>. 
+This guide explains which neural network models are trained and tested in the traffic light classifier node and for future developments it can help about replace current model to another model without changing TensorRT layers.
 
-After creating custom dataset, you can download pretrained models or you can train a model from scratch. If you want to train from scratch, you can use `pretrained=False`  option when use `torchvision`models.
+After creating custom dataset, you can download default pretrained models. If you want to train without pretrained weights, you can use `pretrained=False`  option when use `torchvision`models.
 
-All models in referenced link trained and converted the `onnx` format. After that trained models tested on `traffic_light_classifier`.<https://github.com/qfgaohao/pytorch-ssd>.
+All models in referenced link are  trained and converted the `onnx` format. Here is a link for this onnx conversion <https://deci.ai/blog/how-to-convert-a-pytorch-model-to-onnx/>.
+After that trained models tested on the `traffic_light_classifier` node and here is link for which models are used <https://pytorch.org/vision/0.8/models.html>.
+
+Requirements for the tested models are below:
+
+- `torch==1.12.1+cu116`
+- `torchvision==0.13.1+cu116`
+- `onnx==1.13.0`
+
+Currently, the traffic light classifier node supports the following models with requirements above:
+- `MobileNet v2`
+- `ResNet`
+- `DenseNet`
+- `SqueezeNet`
+- `GoogLeNet`
+- `ShuffleNet v2`
+- `Wide ResNet`
+- `ResNeXt`
+
+These models are supported by TensorRT and can be converted  to `onnx` and `trt engine` files. Then they can be used directly in the `traffic_light_classifier` node.

--- a/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
+++ b/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
@@ -14,13 +14,15 @@ Requirements for the tested models are below:
 - `onnx==1.13.0`
 
 Currently, the traffic light classifier node supports the following models with requirements above:
+
+- `DenseNet`
+- `GoogLeNet`
 - `MobileNet v2`
 - `ResNet`
-- `DenseNet`
-- `SqueezeNet`
-- `GoogLeNet`
+- `ResNeXt`
 - `ShuffleNet v2`
-- `Wide ResNet`
+- `SqueezeNet`
+
 
 
 These models are supported by TensorRT and can be converted  to `onnx` and `trt engine` files. Then they can be used directly in the `traffic_light_classifier` node.

--- a/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
+++ b/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
@@ -1,5 +1,4 @@
-# How to Test Different Neural Network Models from Pytorch Hub inside Traffic Light Classifier Node
-
+# How to Deploy Different Neural Network Models from Pytorch Hub inside Traffic Light Classifier Node
 Currently in Autoware ,we can re-train compatible models as base  from Pytorch hub and use it in traffic_light_classifier node. Here is a tutorial link for training <https://pytorch.org/tutorials/advanced/super_resolution_with_onnxruntime.html>. 
 This guide explains which neural network models are trained and tested in the traffic light classifier node and for future developments it can help about replace current model to another model without changing TensorRT layers.
 
@@ -22,6 +21,6 @@ Currently, the traffic light classifier node supports the following models with 
 - `GoogLeNet`
 - `ShuffleNet v2`
 - `Wide ResNet`
-- `ResNeXt`
+
 
 These models are supported by TensorRT and can be converted  to `onnx` and `trt engine` files. Then they can be used directly in the `traffic_light_classifier` node.

--- a/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
+++ b/docs/how-to-guides/traffic-light-classifier-node-different-model-testing.md
@@ -1,0 +1,7 @@
+# How to Train Different Neural Network Models from Pytorch Hub inside Traffic Light Classifier Node
+
+Currently in Autoware , the traffic light classifier node uses  pre-trained MobileNet V2 neural network model from Pytorch Hub. Also you can train a new neural network model using the Pytorch Hub model as a base model. This guide explains how to train a new neural network model and use it in the traffic light classifier node.
+
+After creating custom dataset, you can download pretrained models or you can train a model from scratch. If you want to train from scratch, you can use `pretrained=False`  option when use `torchvision`models.
+
+All models in referenced link trained and converted the `onnx` format. After that trained models tested on `traffic_light_classifier`.<https://github.com/qfgaohao/pytorch-ssd>.

--- a/docs/how-to-guides/traffic-light-classifier-node-training.md
+++ b/docs/how-to-guides/traffic-light-classifier-node-training.md
@@ -1,0 +1,1 @@
+# hello world

--- a/docs/how-to-guides/traffic-light-classifier-node-training.md
+++ b/docs/how-to-guides/traffic-light-classifier-node-training.md
@@ -1,1 +1,0 @@
-# hello world


### PR DESCRIPTION
## Description
With this pull request models in torchvision hub trained again and tested which ones are compatible with current traffic_light_classifier node to make using another model optional.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
