### PR TITLE
feat(contributing): add the definition of standard change and small change for PR

### DIFF
--- a/docs/contributing/pull-request-guidelines/index.md
+++ b/docs/contributing/pull-request-guidelines/index.md
@@ -50,7 +50,7 @@ Use this workflow as a reference when you contribute to Autoware.
 
 #### Example
 
-- There are two types of template. Select one based on the following condition.
+There are two types of templates. Select one based on the following condition.
 
 1. [Standard change](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/standard-change.md):
 

--- a/docs/contributing/pull-request-guidelines/index.md
+++ b/docs/contributing/pull-request-guidelines/index.md
@@ -50,7 +50,7 @@ Use this workflow as a reference when you contribute to Autoware.
 
 #### Condition
 
-- There are two types of template. One is [small change template](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/small-change.md) and the other one is [standard change template](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/standard-change.md). Please select one based on the following condition.
+- There are two types of template. One is [small change template](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/small-change.md) and the other one is [standard change template](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/standard-change.md). Select one based on the following condition.
 
 1. Standard Change:
 

--- a/docs/contributing/pull-request-guidelines/index.md
+++ b/docs/contributing/pull-request-guidelines/index.md
@@ -48,7 +48,7 @@ Use this workflow as a reference when you contribute to Autoware.
 
 - The unified style of descriptions by templates can make reviews efficient.
 
-#### Condition
+#### Example
 
 - There are two types of template. One is [small change template](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/small-change.md) and the other one is [standard change template](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/standard-change.md). Select one based on the following condition.
 
@@ -62,7 +62,7 @@ Use this workflow as a reference when you contribute to Autoware.
 - Complexity: A small change typically involves low complexity, such as updating documentation, making simple refactoring, or adjusting code style. These changes can usually be understood and reviewed quickly, often without extensive collaboration or deep knowledge of the entire codebase.
 - Impact: A small change has a limited or localized impact on the system. It might affect only a specific component or have minimal implications for the system's overall functionality or performance. Small changes generally do not include minor feature additions or minor bug fixes, as those should be treated as standard changes due to their impact. These small changes can generally be merged more quickly and with less rigorous testing.
 
-#### Example
+#### Steps to use an appropriate pull request template
 
 1. Select the appropriate template, as shown in [this video](https://user-images.githubusercontent.com/31987104/184344710-2adee239-799f-4fdf-bfab-be76345bfac1.mp4).
 2. Read the selected template carefully and fill the required content.

--- a/docs/contributing/pull-request-guidelines/index.md
+++ b/docs/contributing/pull-request-guidelines/index.md
@@ -50,9 +50,9 @@ Use this workflow as a reference when you contribute to Autoware.
 
 #### Example
 
-- There are two types of template. One is [small change template](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/small-change.md) and the other one is [standard change template](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/standard-change.md). Select one based on the following condition.
+- There are two types of template. Select one based on the following condition.
 
-1. Standard Change:
+1. Standard change:
 
 - Complexity:
   - Moderate to high, including new features, architectural changes, or addressing multiple issues.
@@ -62,7 +62,7 @@ Use this workflow as a reference when you contribute to Autoware.
   - Includes minor feature additions and minor bug fixes.
   - Requires thorough testing and evaluation before merging.
 
-2. Small Change:
+2. Small change:
 
 - Complexity:
   - Low, such as documentation updates, simple refactoring, or code style adjustments.

--- a/docs/contributing/pull-request-guidelines/index.md
+++ b/docs/contributing/pull-request-guidelines/index.md
@@ -53,23 +53,20 @@ Use this workflow as a reference when you contribute to Autoware.
 There are two types of templates. Select one based on the following condition.
 
 1. [Standard change](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/standard-change.md):
-
-- Complexity:
-  - New features or significant updates.
-  - Requires deeper understanding of the codebase.
-- Impact:
-  - Affects multiple parts of the system.
-  - Basically includes minor features, bug fixes and performance improvement.
-  - Needs testing before merging.
-
+   - Complexity:
+     - New features or significant updates.
+     - Requires deeper understanding of the codebase.
+   - Impact:
+     - Affects multiple parts of the system.
+     - Basically includes minor features, bug fixes and performance improvement.
+     - Needs testing before merging.
 2. [Small change](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/small-change.md):
-
-- Complexity:
-  - Documentation, simple refactoring, or style adjustments.
-  - Easy to understand and review.
-- Impact:
-  - Minimal effect on the system.
-  - Quicker merge with less testing needed.
+   - Complexity:
+     - Documentation, simple refactoring, or style adjustments.
+     - Easy to understand and review.
+   - Impact:
+     - Minimal effect on the system.
+     - Quicker merge with less testing needed.
 
 ##### Steps to use an appropriate pull request template
 

--- a/docs/contributing/pull-request-guidelines/index.md
+++ b/docs/contributing/pull-request-guidelines/index.md
@@ -55,22 +55,22 @@ There are two types of templates. Select one based on the following condition.
 1. [Standard change](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/standard-change.md):
 
 - Complexity:
-  - Moderate to high, including new features, architectural changes, or addressing multiple issues.
-  - Requires deeper understanding of the codebase and collaboration.
+  - New features or significant updates.
+  - Requires deeper understanding of the codebase.
 - Impact:
-  - Broader system impact, affecting multiple components, functionality, or performance.
-  - Includes minor feature additions and minor bug fixes.
-  - Requires thorough testing and evaluation before merging.
+  - Affects multiple parts of the system.
+  - Includes minor features and bug fixes.
+  - Needs testing before merging.
 
 2. [Small change](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/small-change.md):
 
 - Complexity:
-  - Low, such as documentation updates, simple refactoring, or code style adjustments.
-  - Easy to understand and review without extensive collaboration or deep knowledge of the codebase.
+  - Documentation, simple refactoring, or style adjustments.
+  - Easy to understand and review.
 - Impact:
-  - Limited or localized system impact, affecting specific components or having minimal implications on functionality or performance.
-  - Excludes minor feature additions and minor bug fixes.
-  - Can be merged quickly with less rigorous testing.
+  - Minimal effect on the system.
+  - Exclude minor features or bug fixes.
+  - Quicker merge with less testing needed.
 
 ##### Steps to use an appropriate pull request template
 

--- a/docs/contributing/pull-request-guidelines/index.md
+++ b/docs/contributing/pull-request-guidelines/index.md
@@ -59,7 +59,7 @@ There are two types of templates. Select one based on the following condition.
   - Requires deeper understanding of the codebase.
 - Impact:
   - Affects multiple parts of the system.
-  - Includes minor features and bug fixes.
+  - Basically includes minor features, bug fixes and performance improvement.
   - Needs testing before merging.
 
 2. [Small change](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/small-change.md):
@@ -69,7 +69,6 @@ There are two types of templates. Select one based on the following condition.
   - Easy to understand and review.
 - Impact:
   - Minimal effect on the system.
-  - Exclude minor features or bug fixes.
   - Quicker merge with less testing needed.
 
 ##### Steps to use an appropriate pull request template

--- a/docs/contributing/pull-request-guidelines/index.md
+++ b/docs/contributing/pull-request-guidelines/index.md
@@ -54,15 +54,25 @@ Use this workflow as a reference when you contribute to Autoware.
 
 1. Standard Change:
 
-- Complexity: A standard change involves moderate to high complexity, such as implementing new features, making architectural changes, or addressing multiple interconnected issues. These changes often require a deeper understanding of the codebase and might involve collaboration with other team members.
-- Impact: A standard change has a broader impact on the overall system. It might affect multiple components, alter the system's functionality, or influence performance in a significant way. This category includes minor feature additions and minor bug fixes that, while not necessarily complex, have notable consequences for the system. These changes often require thorough testing and evaluation before they can be merged into the main branch.
+- Complexity:
+  - Moderate to high, including new features, architectural changes, or addressing multiple issues.
+  - Requires deeper understanding of the codebase and collaboration.
+- Impact:
+  - Broader system impact, affecting multiple components, functionality, or performance.
+  - Includes minor feature additions and minor bug fixes.
+  - Requires thorough testing and evaluation before merging.
 
 2. Small Change:
 
-- Complexity: A small change typically involves low complexity, such as updating documentation, making simple refactoring, or adjusting code style. These changes can usually be understood and reviewed quickly, often without extensive collaboration or deep knowledge of the entire codebase.
-- Impact: A small change has a limited or localized impact on the system. It might affect only a specific component or have minimal implications for the system's overall functionality or performance. Small changes generally do not include minor feature additions or minor bug fixes, as those should be treated as standard changes due to their impact. These small changes can generally be merged more quickly and with less rigorous testing.
+- Complexity:
+  - Low, such as documentation updates, simple refactoring, or code style adjustments.
+  - Easy to understand and review without extensive collaboration or deep knowledge of the codebase.
+- Impact:
+  - Limited or localized system impact, affecting specific components or having minimal implications on functionality or performance.
+  - Excludes minor feature additions and minor bug fixes.
+  - Can be merged quickly with less rigorous testing.
 
-#### Steps to use an appropriate pull request template
+##### Steps to use an appropriate pull request template
 
 1. Select the appropriate template, as shown in [this video](https://user-images.githubusercontent.com/31987104/184344710-2adee239-799f-4fdf-bfab-be76345bfac1.mp4).
 2. Read the selected template carefully and fill the required content.

--- a/docs/contributing/pull-request-guidelines/index.md
+++ b/docs/contributing/pull-request-guidelines/index.md
@@ -48,6 +48,19 @@ Use this workflow as a reference when you contribute to Autoware.
 
 - The unified style of descriptions by templates can make reviews efficient.
 
+#### Condition
+
+- There are two types of template. One is [small change template](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/small-change.md) and the other one is [standard change template](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/standard-change.md). Please select one based on the following condition.
+
+1. Standard Change:
+
+-  Complexity: A standard change involves moderate to high complexity, such as implementing new features, making architectural changes, or addressing multiple interconnected issues. These changes often require a deeper understanding of the codebase and might involve collaboration with other team members.
+- Impact: A standard change has a broader impact on the overall system. It might affect multiple components, alter the system's functionality, or influence performance in a significant way. This category includes minor feature additions and minor bug fixes that, while not necessarily complex, have notable consequences for the system. These changes often require thorough testing and evaluation before they can be merged into the main branch.
+
+2. Small Change:
+- Complexity: A small change typically involves low complexity, such as updating documentation, making simple refactoring, or adjusting code style. These changes can usually be understood and reviewed quickly, often without extensive collaboration or deep knowledge of the entire codebase.
+- Impact: A small change has a limited or localized impact on the system. It might affect only a specific component or have minimal implications for the system's overall functionality or performance. Small changes generally do not include minor feature additions or minor bug fixes, as those should be treated as standard changes due to their impact. These small changes can generally be merged more quickly and with less rigorous testing.
+
 #### Example
 
 1. Select the appropriate template, as shown in [this video](https://user-images.githubusercontent.com/31987104/184344710-2adee239-799f-4fdf-bfab-be76345bfac1.mp4).

--- a/docs/contributing/pull-request-guidelines/index.md
+++ b/docs/contributing/pull-request-guidelines/index.md
@@ -54,10 +54,11 @@ Use this workflow as a reference when you contribute to Autoware.
 
 1. Standard Change:
 
--  Complexity: A standard change involves moderate to high complexity, such as implementing new features, making architectural changes, or addressing multiple interconnected issues. These changes often require a deeper understanding of the codebase and might involve collaboration with other team members.
+- Complexity: A standard change involves moderate to high complexity, such as implementing new features, making architectural changes, or addressing multiple interconnected issues. These changes often require a deeper understanding of the codebase and might involve collaboration with other team members.
 - Impact: A standard change has a broader impact on the overall system. It might affect multiple components, alter the system's functionality, or influence performance in a significant way. This category includes minor feature additions and minor bug fixes that, while not necessarily complex, have notable consequences for the system. These changes often require thorough testing and evaluation before they can be merged into the main branch.
 
 2. Small Change:
+
 - Complexity: A small change typically involves low complexity, such as updating documentation, making simple refactoring, or adjusting code style. These changes can usually be understood and reviewed quickly, often without extensive collaboration or deep knowledge of the entire codebase.
 - Impact: A small change has a limited or localized impact on the system. It might affect only a specific component or have minimal implications for the system's overall functionality or performance. Small changes generally do not include minor feature additions or minor bug fixes, as those should be treated as standard changes due to their impact. These small changes can generally be merged more quickly and with less rigorous testing.
 

--- a/docs/contributing/pull-request-guidelines/index.md
+++ b/docs/contributing/pull-request-guidelines/index.md
@@ -52,7 +52,7 @@ Use this workflow as a reference when you contribute to Autoware.
 
 - There are two types of template. Select one based on the following condition.
 
-1. Standard change:
+1. [Standard change](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/standard-change.md):
 
 - Complexity:
   - Moderate to high, including new features, architectural changes, or addressing multiple issues.
@@ -62,7 +62,7 @@ Use this workflow as a reference when you contribute to Autoware.
   - Includes minor feature additions and minor bug fixes.
   - Requires thorough testing and evaluation before merging.
 
-2. Small change:
+2. [Small change](https://github.com/autowarefoundation/autoware/blob/main/.github/PULL_REQUEST_TEMPLATE/small-change.md):
 
 - Complexity:
   - Low, such as documentation updates, simple refactoring, or code style adjustments.


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Add the definition of standard change and small change for PR template.

The motivation is to ensure that the PR authors do not confuse which template to use. 
e.g. even minor feature or bug fix PR should be written in standard template



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
