### PR TITLE
docs(support/troubleshooting): update information about python setuptools in troubleshooting section

### DIFF
--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -137,13 +137,14 @@ During building the following issue can occurs
 pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: '0.23ubuntu1'
 ```
 
-The error is due to the fact that since version 66.0.0 `setuptools` enforces the python packages to be
+The error is due to the fact that for versions between 66.0.0 and 67.5.0 `setuptools` enforces the python packages to be
 [PEP-440](https://peps.python.org/pep-0440/) conformant.
+Since version 67.5.1 `setuptools` added [fallback](https://github.com/pypa/setuptools/commit/1640731114734043b8500d211366fc941b741f67) that makes it possible to work with old packages again.
 
-The workaround is to lower the version of `setuptools` to 65 or lower. It can be done using the following command
+The solution is to update `setuptools` to the newest version with the following command
 
 ```bash
-pip install -U setuptools==65.7.0
+pip install --upgrade setuptools
 ```
 
 ## Docker/rocker issues

--- a/docs/support/troubleshooting.md
+++ b/docs/support/troubleshooting.md
@@ -139,7 +139,7 @@ pkg_resources.extern.packaging.version.InvalidVersion: Invalid version: '0.23ubu
 
 The error is due to the fact that for versions between 66.0.0 and 67.5.0 `setuptools` enforces the python packages to be
 [PEP-440](https://peps.python.org/pep-0440/) conformant.
-Since version 67.5.1 `setuptools` added [fallback](https://github.com/pypa/setuptools/commit/1640731114734043b8500d211366fc941b741f67) that makes it possible to work with old packages again.
+Since version 67.5.1 `setuptools` has a [fallback](https://github.com/pypa/setuptools/commit/1640731114734043b8500d211366fc941b741f67) that makes it possible to work with old packages again.
 
 The solution is to update `setuptools` to the newest version with the following command
 


### PR DESCRIPTION
Related to the issue https://github.com/autowarefoundation/autoware.universe/issues/2755

## Description

Updated information about setuptools in the troubleshooting section.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
