### PR TITLE
docs: add scenario simulation page

### DIFF
--- a/docs/tutorials/scenario-simulation/.pages
+++ b/docs/tutorials/scenario-simulation/.pages
@@ -1,3 +1,4 @@
 nav:
+  - index.md
   - planning-simulation
   - rosbag-replay-simulation

--- a/docs/tutorials/scenario-simulation/index.md
+++ b/docs/tutorials/scenario-simulation/index.md
@@ -1,0 +1,5 @@
+# Scenario simulation
+
+!!! warning
+
+    Under Construction


### PR DESCRIPTION
## Description
Add scenario simulation page because 
![image](https://user-images.githubusercontent.com/8327598/235968829-4ce23089-5fc7-4003-b3fa-254fafcaed09.png)
Adhoc sim has a page provided, but scenerio sim does not have a page provided and is not in bold black type.
It is difficult for users to see that there are two, Adhoc and Scenario, which can be confusing.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
