### PR TITLE
docs(planning-interface): update to the latest interface information

### DIFF
--- a/docs/design/autoware-interfaces/components/planning.md
+++ b/docs/design/autoware-interfaces/components/planning.md
@@ -1,6 +1,6 @@
 # Planning
 
-This page provides specific specifications about the Interface of the Planning Component. Please refer to the [planning architecture design document](../autoware-architecture/planning/index.md) for high-level concepts and data flow.
+This page provides specific specifications about the Interface of the Planning Component. Please refer to the [planning architecture design document](../../autoware-architecture/planning/index.md) for high-level concepts and data flow.
 
 **TODO: The detailed definitions (meanings of elements included in each topic) are not described yet, need to be updated.**
 

--- a/docs/design/autoware-interfaces/components/planning.md
+++ b/docs/design/autoware-interfaces/components/planning.md
@@ -2,7 +2,7 @@
 
 This page provides specific specifications about the Interface of the Planning Component. Please refer to the [planning architecture design document](../autoware-architecture/planning/index.md) for high-level concepts and data flow.
 
-**TODO:** The detailed definitions (meanings of elements included in each topic) are not described yet, need to be updated.
+**TODO: The detailed definitions (meanings of elements included in each topic) are not described yet, need to be updated.**
 
 ## Inputs
 


### PR DESCRIPTION
## Description

This PR updates the Planning Interface information to the latest Autoware. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
