### PR TITLE
docs(design/map): add description about dividing map

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -36,7 +36,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Deploy docs
-        uses: autowarefoundation/autoware-github-actions/deploy-docs@main
+        uses: autowarefoundation/autoware-github-actions/deploy-docs@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: ${{ github.event_name != 'pull_request_target' && github.ref_name == github.event.repository.default_branch }}

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -36,7 +36,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Deploy docs
-        uses: autowarefoundation/autoware-github-actions/deploy-docs@v1
+        uses: autowarefoundation/autoware-github-actions/deploy-docs@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: ${{ github.event_name != 'pull_request_target' && github.ref_name == github.event.repository.default_branch }}

--- a/docs/design/autoware-architecture/map/index.md
+++ b/docs/design/autoware-architecture/map/index.md
@@ -61,12 +61,12 @@ If it is split into multiple files, Autoware assumes the following directory str
 ```bash
 sample-map-rosbag
 ├── lanelet2_map.osm
-├── pointcloud_map
-├── pcd_00.pcd
-├── pcd_01.pcd
-├── pcd_02.pcd
-├── ...
-└── pointcloud_map_metadata.yaml
+└── pointcloud_map
+    ├── pcd_00.pcd
+    ├── pcd_01.pcd
+    ├── pcd_02.pcd
+    ├── ...
+    └── pointcloud_map_metadata.yaml
 ```
 
 Note that, if you split the map into multiple files, you must meet the following additional conditions:
@@ -79,13 +79,24 @@ Metadata should look like as follows:
 ```yaml
 x_resolution: 100.0
 y_resolution: 150.0
-A.pcd: [1200, 2500] # -> 1200 < x < 1300, 2500 < y < 2650
-B.pcd: [1300, 2500] # -> 1300 < x < 1400, 2500 < y < 2650
-C.pcd: [1200, 2650] # -> 1200 < x < 1300, 2650 < y < 2800
-D.pcd: [1400, 2650] # -> 1400 < x < 1500, 2650 < y < 2800
+pcd_00.pcd: [1200, 2500] # -> 1200 < x < 1300, 2500 < y < 2650
+pcd_01.pcd: [1300, 2500] # -> 1300 < x < 1400, 2500 < y < 2650
+pcd_02.pcd: [1200, 2650] # -> 1200 < x < 1300, 2650 < y < 2800
+pcd_03.pcd: [1400, 2650] # -> 1400 < x < 1500, 2650 < y < 2800
+...
 ```
 
 You may use [pointcloud_divider](https://github.com/MapIV/pointcloud_divider) from MAP IV for dividing pointcloud map as well as generating the compatible metadata.yaml.
+
+To load multiple PCD files when launching Autoware, specify the name of the directory containing the PCD files as an argument.
+
+[Example]
+
+```bash
+pointcloud_map_file:=pointcloud_map
+```
+
+This argument is concatenated with the `map_path` argument given to Autoware, and all *.pcd files located in that directory will be loaded.
 
 #### Vector Map
 

--- a/docs/design/autoware-architecture/map/index.md
+++ b/docs/design/autoware-architecture/map/index.md
@@ -83,7 +83,6 @@ pcd_00.pcd: [1200, 2500] # -> 1200 < x < 1300, 2500 < y < 2650
 pcd_01.pcd: [1300, 2500] # -> 1300 < x < 1400, 2500 < y < 2650
 pcd_02.pcd: [1200, 2650] # -> 1200 < x < 1300, 2650 < y < 2800
 pcd_03.pcd: [1400, 2650] # -> 1400 < x < 1500, 2650 < y < 2800
-...
 ```
 
 You may use [pointcloud_divider](https://github.com/MapIV/pointcloud_divider) from MAP IV for dividing pointcloud map as well as generating the compatible metadata.yaml.
@@ -96,7 +95,7 @@ To load multiple PCD files when launching Autoware, specify the name of the dire
 pointcloud_map_file:=pointcloud_map
 ```
 
-This argument is concatenated with the `map_path` argument given to Autoware, and all *.pcd files located in that directory will be loaded.
+This argument is concatenated with the `map_path` argument given to Autoware, and all \*.pcd files located in that directory will be loaded.
 
 #### Vector Map
 


### PR DESCRIPTION
## Description

This PR adds description about dividing map.

One concern is that this description slightly differs from the one on the following page.

https://github.com/autowarefoundation/autoware.universe/tree/main/map/map_loader

for example

```
sample-map-rosbag
├── lanelet2_map.osm
├── pointcloud_map.pcd
│ ├── A.pcd
│ ├── B.pcd
│ ├── C.pcd
│ └── ...
└── pointcloud_map_metadata.yaml
```

I think that maintaining duplicate documents can be challenging, so it might be beneficial to link one to the other.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
