### PR TITLE
docs: fix the typo (trajectory -> path).

### DIFF
--- a/docs/design/autoware-architecture/planning/index.md
+++ b/docs/design/autoware-architecture/planning/index.md
@@ -33,7 +33,7 @@ The Planning component consists of the following sub-components:
 - **Mission Planning**: Calculates the route based on the given goal and map information.
 - **Scenario Planning**: Determines the trajectory based on the current scenario, such as Lane Driving or Parking.
   - **Lane Driving**: Calculates the trajectory for driving within constructed lanes.
-    - **Behavior Planner**: Calculates suitable trajectory based on safety considerations and traffic rules.
+    - **Behavior Planner**: Calculates suitable path based on safety considerations and traffic rules.
     - **Motion Planner**: Calculates suitable trajectory for the vehicle by taking into account safety factors, vehicle motion considerations, and instructions from the behavior planner.
   - **Parking**: Calculates the trajectory for parking in unstructured areas.
 - **Validation**: Verifies the safety of the trajectory.


### PR DESCRIPTION
##  Description

"Behavior Planner" calculates "path", not "trajectory", so I corrected
#427 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
