### PR TITLE
docs(reference-hw): add nebula

### DIFF
--- a/docs/reference-hw/full_drivers_list.md
+++ b/docs/reference-hw/full_drivers_list.md
@@ -2,18 +2,19 @@
 
 The list of all drivers listed above for easy access as a table with additional information:
 
-| Type   | Maker         | Driver links                                                                   | License  | Maintainer                                   |
-| ------ | ------------- | ------------------------------------------------------------------------------ | -------- | -------------------------------------------- |
-| Lidar  | Velodyne      | [Link](https://github.com/ros-drivers/velodyne/tree/ros2/velodyne_pointcloud)  | BSD      | jwhitley@autonomoustuff.com                  |
-| Lidar  | Robosense     | [Link](https://github.com/RoboSense-LiDAR/rslidar_sdk)                         | BSD      | zdxiao@robosense.cn                          |
-| Lidar  | Hesai         | [Link](https://github.com/HesaiTechnology/HesaiLidar_General_ROS)              | Apache 2 | wuxiaozhou@hesaitech.com                     |
-| Lidar  | Leishen       | [Link](https://github.com/leishen-lidar)                                       | -        | -                                            |
-| Lidar  | Livox         | [Link](https://github.com/Livox-SDK/livox_ros2_driver)                         | MIT      | dev@livoxtech.com                            |
-| Lidar  | Ouster        | [Link](https://github.com/ros-drivers/ros2_ouster_drivers)                     | Apache 2 | stevenmacenski@gmail.com, tom@boxrobotics.ai |
-| Radar  | smartmicro    | [Link](https://github.com/smartmicro/smartmicro_ros2_radars)                   | Apache 2 | opensource@smartmicro.de                     |
-| Camera | Flir          | [Link](https://github.com/berndpfrommer/flir_spinnaker_ros2)                   | Apache 2 | bernd.pfrommer@gmail.com                     |
-| Camera | Lucid Vision  | [Link](https://gitlab.com/leo-drive/Drivers/arena_camera)                      | -        | kcolak@leodrive.ai                           |
-| Camera | Allied Vision | [Link](https://github.com/neil-rti/avt_vimba_camera)                           | Apache 2 | at@email.com                                 |
-| GNSS   | NovAtel       | [Link](https://github.com/swri-robotics/novatel_gps_driver/tree/dashing-devel) | BSD      | preed@swri.org                               |
-| GNSS   | SBG Systems   | [Link](https://github.com/SBG-Systems/sbg_ros2_driver)                         | MIT      | support@sbg-systems.com                      |
-| GNSS   | PolyExplore   | [Link](https://github.com/polyexplore/ROS2_Driver)                             | -        | support@polyexplore.com                      |
+| Type   | Maker             | Driver links                                                                   | License  | Maintainer                                     |
+| ------ | ----------------- | ------------------------------------------------------------------------------ | -------- | ---------------------------------------------- |
+| Lidar  | Velodyne<br>Hesai | [Link](https://github.com/tier4/nebula)                                        | Apache 2 | david.wong@tier4.jp<br>abraham.monrroy@map4.jp |
+| Lidar  | Velodyne          | [Link](https://github.com/ros-drivers/velodyne/tree/ros2/velodyne_pointcloud)  | BSD      | jwhitley@autonomoustuff.com                    |
+| Lidar  | Robosense         | [Link](https://github.com/RoboSense-LiDAR/rslidar_sdk)                         | BSD      | zdxiao@robosense.cn                            |
+| Lidar  | Hesai             | [Link](https://github.com/HesaiTechnology/HesaiLidar_General_ROS)              | Apache 2 | wuxiaozhou@hesaitech.com                       |
+| Lidar  | Leishen           | [Link](https://github.com/leishen-lidar)                                       | -        | -                                              |
+| Lidar  | Livox             | [Link](https://github.com/Livox-SDK/livox_ros2_driver)                         | MIT      | dev@livoxtech.com                              |
+| Lidar  | Ouster            | [Link](https://github.com/ros-drivers/ros2_ouster_drivers)                     | Apache 2 | stevenmacenski@gmail.com<br>tom@boxrobotics.ai |
+| Radar  | smartmicro        | [Link](https://github.com/smartmicro/smartmicro_ros2_radars)                   | Apache 2 | opensource@smartmicro.de                       |
+| Camera | Flir              | [Link](https://github.com/berndpfrommer/flir_spinnaker_ros2)                   | Apache 2 | bernd.pfrommer@gmail.com                       |
+| Camera | Lucid Vision      | [Link](https://gitlab.com/leo-drive/Drivers/arena_camera)                      | -        | kcolak@leodrive.ai                             |
+| Camera | Allied Vision     | [Link](https://github.com/neil-rti/avt_vimba_camera)                           | Apache 2 | at@email.com                                   |
+| GNSS   | NovAtel           | [Link](https://github.com/swri-robotics/novatel_gps_driver/tree/dashing-devel) | BSD      | preed@swri.org                                 |
+| GNSS   | SBG Systems       | [Link](https://github.com/SBG-Systems/sbg_ros2_driver)                         | MIT      | support@sbg-systems.com                        |
+| GNSS   | PolyExplore       | [Link](https://github.com/polyexplore/ROS2_Driver)                             | -        | support@polyexplore.com                        |

--- a/docs/reference-hw/lidars.md
+++ b/docs/reference-hw/lidars.md
@@ -12,9 +12,9 @@ Velodyne Lidars which has ROS 2 driver and tested by one or more community membe
 | Puck Hi-res             | 100m  | (+10°)/(-10°), (360°) | Y            | Y                     |
 
 Link to ROS 2 drivers:  
- [https://github.com/tier4/nebula](https://github.com/tier4/nebula)
- [https://github.com/ros-drivers/velodyne/tree/ros2/velodyne_pointcloud](https://github.com/ros-drivers/velodyne/tree/ros2/velodyne_pointcloud)  
- [https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/tree/master/src/drivers/velodyne_nodes](https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/tree/master/src/drivers/velodyne_nodes)
+[https://github.com/tier4/nebula](https://github.com/tier4/nebula)  
+[https://github.com/ros-drivers/velodyne/tree/ros2/velodyne_pointcloud](https://github.com/ros-drivers/velodyne/tree/ros2/velodyne_pointcloud)  
+[https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/tree/master/src/drivers/velodyne_nodes](https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/tree/master/src/drivers/velodyne_nodes)
 [https://github.com/autowarefoundation/awf_velodyne/tree/tier4/universe](https://github.com/autowarefoundation/awf_velodyne/tree/tier4/universe)
 
 Link to company website:  
@@ -49,7 +49,7 @@ Hesai Lidars which has ROS 2 driver and tested by one or more community members 
 | Pandar XT               | 120m  | (+15°)/(-16°), (360°)  | Y            | Y                     |
 | Pandar QT               | 20m   | (-52.1°/+52.1°)/(360°) | Y            | Y                     |
 
-Link to ROS 2 drivers:
+Link to ROS 2 drivers:  
 [https://github.com/tier4/nebula](https://github.com/tier4/nebula)  
 [https://github.com/HesaiTechnology/HesaiLidar_General_ROS](https://github.com/HesaiTechnology/HesaiLidar_General_ROS)
 

--- a/docs/reference-hw/lidars.md
+++ b/docs/reference-hw/lidars.md
@@ -12,6 +12,7 @@ Velodyne Lidars which has ROS 2 driver and tested by one or more community membe
 | Puck Hi-res             | 100m  | (+10°)/(-10°), (360°) | Y            | Y                     |
 
 Link to ROS 2 drivers:  
+ [https://github.com/tier4/nebula](https://github.com/tier4/nebula)
  [https://github.com/ros-drivers/velodyne/tree/ros2/velodyne_pointcloud](https://github.com/ros-drivers/velodyne/tree/ros2/velodyne_pointcloud)  
  [https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/tree/master/src/drivers/velodyne_nodes](https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/-/tree/master/src/drivers/velodyne_nodes)
 [https://github.com/autowarefoundation/awf_velodyne/tree/tier4/universe](https://github.com/autowarefoundation/awf_velodyne/tree/tier4/universe)
@@ -43,11 +44,13 @@ Hesai Lidars which has ROS 2 driver and tested by one or more community members 
 | Supported Products List | Range | FOV (V), (H)           | ROS 2 Driver | Autoware Tested (Y/N) |
 | ----------------------- | ----- | ---------------------- | ------------ | --------------------- |
 | Pandar 128              | 200m  | (+15°)/(-25°), (360°)  | Y            | -                     |
-| Pandar 64               | 200m  | (+15°)/(-25°), (360°)  | Y            | -                     |
-| Pandar XT               | 120m  | (+15°)/(-16°), (360°)  | Y            | -                     |
-| Pandar QT               | 20m   | (-52.1°/+52.1°)/(360°) | Y            | -                     |
+| Pandar 64               | 200m  | (+15°)/(-25°), (360°)  | Y            | Y                     |
+| Pandar 40P              | 200m  | (+15°)/(-25°), (360°)  | Y            | Y                     |
+| Pandar XT               | 120m  | (+15°)/(-16°), (360°)  | Y            | Y                     |
+| Pandar QT               | 20m   | (-52.1°/+52.1°)/(360°) | Y            | Y                     |
 
-Link to ROS 2 driver:  
+Link to ROS 2 drivers:
+[https://github.com/tier4/nebula](https://github.com/tier4/nebula)  
 [https://github.com/HesaiTechnology/HesaiLidar_General_ROS](https://github.com/HesaiTechnology/HesaiLidar_General_ROS)
 
 Link to company website:  


### PR DESCRIPTION
## Description

This PR adds links to the Nebula sensor driver to relevant supported reference hardware (Velodyne and Hesai).
This is the driver currently employed by default in Autoware Universe (see https://github.com/autowarefoundation/autoware/pull/3699).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
