### PR TITLE
fix: add rosbag replay option "--clock"

### DIFF
--- a/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
@@ -44,7 +44,7 @@
 
    ```sh
    source ~/autoware/install/setup.bash
-   ros2 bag play ~/autoware_map/sample-rosbag/sample.db3 -r 0.2 -s sqlite3
+   ros2 bag play ~/autoware_map/sample-rosbag/sample.db3 -r 0.2 -s sqlite3 --clock 100
    ```
 
    ![after-rosbag-play](images/rosbag-replay/after-rosbag-play.png)


### PR DESCRIPTION
## Description
fix: add rosbag replay option "--clock" to be activate time triggerd sub-modules, such as the lateral control module

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
