### PR TITLE
docs(installation): add link to manual artifacts downloading instruction

### DIFF
--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -61,7 +61,7 @@ sudo apt-get -y install git
     - [Install Nvidia CUDA](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/cuda#manual-installation)
     - [Install Nvidia cuDNN and TensorRT](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/tensorrt#manual-installation)
 
-    If you didn't use ansible script you will need to download some package artifacts as explained in [Manual loading of artifacts](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts). Otherwise some packages (mostly from perception) will not be able to run as they need these artifacts for the inference. 
+    If you didn't use ansible script you will need to download some package artifacts as explained in [Manual loading of artifacts](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts). Otherwise some packages (mostly from perception) will not be able to run as they need these artifacts for the inference.
 
 ## How to set up a workspace
 

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -61,6 +61,8 @@ sudo apt-get -y install git
     - [Install Nvidia CUDA](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/cuda#manual-installation)
     - [Install Nvidia cuDNN and TensorRT](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/tensorrt#manual-installation)
 
+    If you didn't use ansible script you will need to download some package artifacts as explained in [Manual loading of artifacts](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts). Otherwise some packages (mostly from perception) will not be able to run as they need these artifacts for the inference. 
+
 ## How to set up a workspace
 
 1. Create the `src` directory and clone repositories into it.


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Belongs to [Standardize a strategy for packages with downloaded artifacts](https://github.com/orgs/autowarefoundation/discussions/3649)

Add information about manual downloading packages artifacts if ansible isn't used. 

See https://github.com/autowarefoundation/autoware.universe/issues/3137
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
