### PR TITLE
docs(tutorials): add link to manual artifacts downloading

### DIFF
--- a/docs/tutorials/ad-hoc-simulation/planning-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/planning-simulation.md
@@ -31,7 +31,7 @@ traffic_light_ssd_fine_detector
 yabloc_pose_initializer
 ```
 
-If not, please, follow [Manual dowloading of artifacts](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts).
+If not, please, follow [Manual downloading of artifacts](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts).
 
 ## Basic simulations
 

--- a/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
@@ -36,7 +36,7 @@
    yabloc_pose_initializer
    ```
 
-   If not, please, follow [Manual dowloading of artifacts](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts).
+   If not, please, follow [Manual downloading of artifacts](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts).
 
 ### Note
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

Belongs to [Standardize a strategy for packages with downloaded artifacts](https://github.com/orgs/autowarefoundation/discussions/3649)

Add information about manual downloading packages artifacts to planning and logging simulators if ansible isn't used. 

See https://github.com/autowarefoundation/autoware.universe/issues/3137
## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
