### PR TITLE
docs(autoware_integration): integration guide improvements

### DIFF
--- a/docs/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description.md
+++ b/docs/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description.md
@@ -14,7 +14,7 @@ This page introduces the custom packages that you should include in your autowar
 
 This guide assumes you will fork Autoware's sample repositories and packages to use as templates for your custom implementation. You can fork Autoware's sample packages:([sample_sensor_kit_launch](https://github.com/autowarefoundation/sample_sensor_kit_launch.git) , [sample_vehicle_launch](https://github.com/autowarefoundation/sample_vehicle_launch.git), and [autoware_individual_params](https://github.com/autowarefoundation/autoware_individual_params.git)), and rename their folders and files according to your vehicle name/denomination. If you do so, you should have folder structures like these:
 
-```
+```bash
 YOUR_VEHICLE_launch (Custom Repository)
 ├── YOUR_VEHICLE_description (Package)
 │ ├── CMakeLists.txt

--- a/docs/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description.md
+++ b/docs/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description.md
@@ -15,7 +15,7 @@ This page introduces the custom packages that you should include in your autowar
 This guide assumes you will fork Autoware's sample repositories and packages to use as templates for your custom implementation. You can fork Autoware's sample packages:([sample_sensor_kit_launch](https://github.com/autowarefoundation/sample_sensor_kit_launch.git) , [sample_vehicle_launch](https://github.com/autowarefoundation/sample_vehicle_launch.git), and [autoware_individual_params](https://github.com/autowarefoundation/autoware_individual_params.git)), and rename their folders and files according to your vehicle name/denomination. If do so, you should have folder structures like these:
 
 ```
-YOUR_VEHICLE_launch (Custom Repository name)
+YOUR_VEHICLE_launch (Custom Repository)
 ├── YOUR_VEHICLE_description (package)
 │ ├── CMakeLists.txt
 │ ├── config
@@ -34,7 +34,7 @@ YOUR_VEHICLE_launch (Custom Repository name)
 │ └── package.xml
 └── ...
 
-YOUR_SENSOR_KIT_launch (Custom Repository name)
+YOUR_SENSOR_KIT_launch (Custom Repository)
 ├── common_sensor_launch
 │ ├── ...
 ├── YOUR_SENSOR_KIT_description (package)
@@ -64,7 +64,7 @@ YOUR_SENSOR_KIT_launch (Custom Repository name)
 ├── README.md
 └── ...
 
-YOUR_AUTOWARE_INDIVIDUAL_PARAMS (Custom Repository name)
+YOUR_AUTOWARE_INDIVIDUAL_PARAMS (Custom Repository)
 ├── individual_params (package)
 │ ├── config
 │ │ └── default

--- a/docs/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description.md
+++ b/docs/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description.md
@@ -12,11 +12,11 @@ This page introduces the custom packages that you should include in your autowar
 
 ## Repository and package structure based on Autoware's sample packages
 
-This guide assumes you will fork Autoware's sample repositories and packages to use as templates for your custom implementation. You can fork Autoware's sample packages:([sample_sensor_kit_launch](https://github.com/autowarefoundation/sample_sensor_kit_launch.git) , [sample_vehicle_launch](https://github.com/autowarefoundation/sample_vehicle_launch.git), and [autoware_individual_params](https://github.com/autowarefoundation/autoware_individual_params.git)), and rename their folders and files according to your vehicle name/denomination. If do so, you should have folder structures like these:
+This guide assumes you will fork Autoware's sample repositories and packages to use as templates for your custom implementation. You can fork Autoware's sample packages:([sample_sensor_kit_launch](https://github.com/autowarefoundation/sample_sensor_kit_launch.git) , [sample_vehicle_launch](https://github.com/autowarefoundation/sample_vehicle_launch.git), and [autoware_individual_params](https://github.com/autowarefoundation/autoware_individual_params.git)), and rename their folders and files according to your vehicle name/denomination. If you do so, you should have folder structures like these:
 
 ```
 YOUR_VEHICLE_launch (Custom Repository)
-├── YOUR_VEHICLE_description (package)
+├── YOUR_VEHICLE_description (Package)
 │ ├── CMakeLists.txt
 │ ├── config
 │ │ ├── mirror.param.yaml (must be changed)
@@ -27,7 +27,7 @@ YOUR_VEHICLE_launch (Custom Repository)
 │ ├── package.xml
 │ └── urdf
 │ └── vehicle.xacro
-├── YOUR_VEHICLE_launch (package)
+├── YOUR_VEHICLE_launch (Package)
 │ ├── CMakeLists.txt
 │ ├── launch
 │ │ └── vehicle_interface.launch.xml (must be changed)
@@ -37,7 +37,7 @@ YOUR_VEHICLE_launch (Custom Repository)
 YOUR_SENSOR_KIT_launch (Custom Repository)
 ├── common_sensor_launch
 │ ├── ...
-├── YOUR_SENSOR_KIT_description (package)
+├── YOUR_SENSOR_KIT_description (Package)
 │ ├── CMakeLists.txt
 │ ├── config
 │ │ ├── sensor_kit_calibration.yaml (NOT USED BY AUTOWARE)
@@ -46,7 +46,7 @@ YOUR_SENSOR_KIT_launch (Custom Repository)
 │ └── urdf
 │ ├── sensor_kit.xacro (must be changed)
 │ └── sensors.xacro (must be changed)
-├── YOUR_SENSOR_KIT_launch (package)
+├── YOUR_SENSOR_KIT_launch (Package)
 │ ├── CMakeLists.txt
 │ ├── config
 │ │ ├── ...
@@ -65,7 +65,7 @@ YOUR_SENSOR_KIT_launch (Custom Repository)
 └── ...
 
 YOUR_AUTOWARE_INDIVIDUAL_PARAMS (Custom Repository)
-├── individual_params (package)
+├── individual_params (Package)
 │ ├── config
 │ │ └── default
 │ │ ├── awsim_sensor_kit

--- a/docs/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description.md
+++ b/docs/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This page introduces the following topics:
+This page introduces the custom packages that you should include in your autoware project to integrate autoware to your vehicle:
 
 1. YOUR_VEHICLE_description
 2. YOUR_SENSOR_KIT_description
@@ -10,14 +10,13 @@ This page introduces the following topics:
 4. YOUR_VEHICLE_launch
 5. YOUR_SENSOR_KIT_launch
 
-These are all custom packages that you should include in your autoware project to integrate autoware to your vehicle.
+## Repository and package structure based on Autoware's sample packages
 
-## Package structure based on Autoware's sample packages
+This guide assumes you will fork Autoware's sample repositories and packages to use as templates for your custom implementation. You can fork Autoware's sample packages:([sample_sensor_kit_launch](https://github.com/autowarefoundation/sample_sensor_kit_launch.git) , [sample_vehicle_launch](https://github.com/autowarefoundation/sample_vehicle_launch.git), and [autoware_individual_params](https://github.com/autowarefoundation/autoware_individual_params.git)), and rename their folders and files according to your vehicle name/denomination. If do so, you should have folder structures like these:
 
-You can fork Autoware's sample packages:[sample_sensor_kit_launch](https://github.com/autowarefoundation/sample_sensor_kit_launch.git) , [sample_vehicle_launch](https://github.com/autowarefoundation/sample_vehicle_launch.git), and [autoware_individual_params](https://github.com/autowarefoundation/autoware_individual_params.git), and rename their folders and files according to your vehicle name/denomination, you should have structures like this:
-
-YOUR_VEHICLE_launch
-├── YOUR_VEHICLE_description
+```
+YOUR_VEHICLE_launch (Custom Repository name)
+├── YOUR_VEHICLE_description (package)
 │ ├── CMakeLists.txt
 │ ├── config
 │ │ ├── mirror.param.yaml (must be changed)
@@ -28,17 +27,17 @@ YOUR_VEHICLE_launch
 │ ├── package.xml
 │ └── urdf
 │ └── vehicle.xacro
-├── YOUR_VEHICLE_launch
+├── YOUR_VEHICLE_launch (package)
 │ ├── CMakeLists.txt
 │ ├── launch
 │ │ └── vehicle_interface.launch.xml (must be changed)
 │ └── package.xml
 └── ...
 
-YOUR_SENSOR_KIT_launch
+YOUR_SENSOR_KIT_launch (Custom Repository name)
 ├── common_sensor_launch
 │ ├── ...
-├── YOUR_SENSOR_KIT_description
+├── YOUR_SENSOR_KIT_description (package)
 │ ├── CMakeLists.txt
 │ ├── config
 │ │ ├── sensor_kit_calibration.yaml (NOT USED BY AUTOWARE)
@@ -47,7 +46,7 @@ YOUR_SENSOR_KIT_launch
 │ └── urdf
 │ ├── sensor_kit.xacro (must be changed)
 │ └── sensors.xacro (must be changed)
-├── YOUR_SENSOR_KIT_launch
+├── YOUR_SENSOR_KIT_launch (package)
 │ ├── CMakeLists.txt
 │ ├── config
 │ │ ├── ...
@@ -65,8 +64,8 @@ YOUR_SENSOR_KIT_launch
 ├── README.md
 └── ...
 
-YOUR_AUTOWARE_INDIVIDUAL_PARAMS
-├── individual_params
+YOUR_AUTOWARE_INDIVIDUAL_PARAMS (Custom Repository name)
+├── individual_params (package)
 │ ├── config
 │ │ └── default
 │ │ ├── awsim_sensor_kit
@@ -78,10 +77,11 @@ YOUR_AUTOWARE_INDIVIDUAL_PARAMS
 │ │ └── sensors_calibration.yaml (must be changed)
 │ └── ...
 └── ...
+```
 
-You can note that the YOUR_VEHICLE_launch repository contains two ROS packages that need to be modified: YOUR_VEHICLE_description, and YOUR_VEHICLE_launch (same name as he repository itself). Likewise, YOUR_SENSOR_KIT_launch also contains two ROS packages that require customization: YOUR_SENSOR_KIT_description and YOUR_SENSOR_KIT_launch (same name as the repo). Finally, YOUR_AUTOWARE_INDIVIDUAL_PARAMS contains information about your sensor implementation.
+Please note that the YOUR_VEHICLE_launch repository contains two ROS packages that need to be modified: YOUR_VEHICLE_description, and YOUR_VEHICLE_launch (same name as he repository itself). Likewise, YOUR_SENSOR_KIT_launch also contains two ROS packages that require customization: YOUR_SENSOR_KIT_description and YOUR_SENSOR_KIT_launch (same name as the repo). Finally, YOUR_AUTOWARE_INDIVIDUAL_PARAMS contains information about your sensor implementation.
 
-NOTE: the YOUR_AUTOWARE_INDIVIDUAL_PARAMS package contains the information about your sensor ki and calibration (sensor_kit_calibration.yaml and sensors_calibration.yaml) Autoware will NOT use the parameters contained in YOUR_SENSOR_KIT_launch/YOUR_SENSOR_KIT_description/config. Please, do not confuse them.
+Also,the YOUR_AUTOWARE_INDIVIDUAL_PARAMS package contains the information about your sensor kit and calibration (sensor_kit_calibration.yaml and sensors_calibration.yaml) Autoware will NOT use the parameters contained in YOUR_SENSOR_KIT_launch/YOUR_SENSOR_KIT_description/config. Please, do not confuse them.
 
 ## 1. YOUR_VEHICLE_launch/YOUR_VEHICLE_description
 
@@ -222,7 +222,7 @@ individual_params/
 +              └─ sensors_calibration.yaml
 ```
 
-## 5.YOUR_VEHICLE_launch/YOUR_VEHICLE_launch
+## 4.YOUR_VEHICLE_launch/YOUR_VEHICLE_launch
 
 The `YOUR_VEHICLE_launch` package is where the launch file for starting the drive system devices is stored.
 

--- a/docs/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description.md
+++ b/docs/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-This page introduce following topics.
+This page introduces the following topics:
 
 1. YOUR_VEHICLE_description
 2. YOUR_SENSOR_KIT_description
@@ -10,9 +10,82 @@ This page introduce following topics.
 4. YOUR_VEHICLE_launch
 5. YOUR_SENSOR_KIT_launch
 
-## 1. YOUR_VEHICLE_description
+These are all custom packages that you should include in your autoware project to integrate autoware to your vehicle.
 
-In `YOUR_VEHICLE_description`, the following configurations are set:
+## Package structure based on Autoware's sample packages
+
+You can fork Autoware's sample packages:[sample_sensor_kit_launch](https://github.com/autowarefoundation/sample_sensor_kit_launch.git) , [sample_vehicle_launch](https://github.com/autowarefoundation/sample_vehicle_launch.git), and [autoware_individual_params](https://github.com/autowarefoundation/autoware_individual_params.git), and rename their folders and files according to your vehicle name/denomination, you should have structures like this:
+
+YOUR_VEHICLE_launch
+├── YOUR_VEHICLE_description
+│ ├── CMakeLists.txt
+│ ├── config
+│ │ ├── mirror.param.yaml (must be changed)
+│ │ ├── simulator_model.param.yaml
+│ │ └── vehicle_info.param.yaml (must be changed)
+│ ├── mesh
+│ │ └── YOUR_VEHICLE_MESH.dae (if you have a .dae mesh, otherwise, use the provided one)
+│ ├── package.xml
+│ └── urdf
+│ └── vehicle.xacro
+├── YOUR_VEHICLE_launch
+│ ├── CMakeLists.txt
+│ ├── launch
+│ │ └── vehicle_interface.launch.xml (must be changed)
+│ └── package.xml
+└── ...
+
+YOUR_SENSOR_KIT_launch
+├── common_sensor_launch
+│ ├── ...
+├── YOUR_SENSOR_KIT_description
+│ ├── CMakeLists.txt
+│ ├── config
+│ │ ├── sensor_kit_calibration.yaml (NOT USED BY AUTOWARE)
+│ │ └── sensors_calibration.yaml (NOT USED BY AUTOWARE)
+│ ├── package.xml
+│ └── urdf
+│ ├── sensor_kit.xacro (must be changed)
+│ └── sensors.xacro (must be changed)
+├── YOUR_SENSOR_KIT_launch
+│ ├── CMakeLists.txt
+│ ├── config
+│ │ ├── ...
+│ │
+│ ├── data
+│ │ └── ...
+│ ├── launch
+│ │ ├── camera.launch.xml
+│ │ ├── gnss.launch.xml
+│ │ ├── imu.launch.xml (must be changed)
+│ │ ├── lidar.launch.xml (must be changed)
+│ │ ├── pointcloud_preprocessor.launch.py (must be changed)
+│ │ └── sensing.launch.xml (must be changed)
+│ └── package.xml
+├── README.md
+└── ...
+
+YOUR_AUTOWARE_INDIVIDUAL_PARAMS
+├── individual_params
+│ ├── config
+│ │ └── default
+│ │ ├── awsim_sensor_kit
+│ │ │ ├── sensor_kit_calibration.yaml
+│ │ │ └── sensors_calibration.yaml
+│ │ └── YOUR_SENSOR_KIT
+│ │ ├── imu_corrector.param.yaml
+│ │ ├── sensor_kit_calibration.yaml (must be changed)
+│ │ └── sensors_calibration.yaml (must be changed)
+│ └── ...
+└── ...
+
+You can note that the YOUR_VEHICLE_launch repository contains two ROS packages that need to be modified: YOUR_VEHICLE_description, and YOUR_VEHICLE_launch (same name as he repository itself). Likewise, YOUR_SENSOR_KIT_launch also contains two ROS packages that require customization: YOUR_SENSOR_KIT_description and YOUR_SENSOR_KIT_launch (same name as the repo). Finally, YOUR_AUTOWARE_INDIVIDUAL_PARAMS contains information about your sensor implementation.
+
+NOTE: the YOUR_AUTOWARE_INDIVIDUAL_PARAMS package contains the information about your sensor ki and calibration (sensor_kit_calibration.yaml and sensors_calibration.yaml) Autoware will NOT use the parameters contained in YOUR_SENSOR_KIT_launch/YOUR_SENSOR_KIT_description/config. Please, do not confuse them.
+
+## 1. YOUR_VEHICLE_launch/YOUR_VEHICLE_description
+
+In the `YOUR_VEHICLE_description` package, the following configurations are set:
 
 1. vehicle_info.param.yaml (must be changed)
 2. mesh file (\*.dae)
@@ -40,16 +113,16 @@ Configuration file for the [simulator environment](https://autowarefoundation.gi
 
 The entry point file that defines the entire URDF of the vehicle. It refers to `sensors.xacro`, which specifies the sensor mounting positions.
 
-## 2. YOUR_SENSOR_KIT_description
+## 2. YOUR_SENSOR_KIT_launch/YOUR_SENSOR_KIT_description
 
-In sensor_kit_description, the following files are configured:
+In the `YOUR_SENSOR_KIT_description` package, the following files are configured:
 
 1. sensors.xacro (must be changed)
 2. sensor_kit.xacro (must be changed)
 
 ### 1. sensors.xacro
 
-Resolves the positions of sensors with `base_link` as the parent frame and defines the positions and orientations based on `sensors_calibration.yaml` in individual_params.
+Resolves the positions of sensors with `base_link` as the parent frame and defines the positions and orientations based on `sensors_calibration.yaml` in `YOUR_AUTOWARE_INDIVIDUAL_PARAMS`.
 
 > In Autoware, `<YOUR_SENSOR_KIT_description>/config/sensors_calibration.yaml` is not used.
 
@@ -60,13 +133,13 @@ The positions and orientations within the kit are defined in `sensor_kit.xacro`.
 
 ### 2. sensor_kit.xacro
 
-Resolves the positions of sensors with `sensor_kit_base_link` as the parent and defines the positions and orientations based on `sensor_kit_calibration.yaml` in individual_params.
+Resolves the positions of sensors with `sensor_kit_base_link` as the parent and defines the positions and orientations based on `sensor_kit_calibration.yaml` in `YOUR_AUTOWARE_INDIVIDUAL_PARAMS`.
 
 > In Autoware, `<YOUR_SENSOR_KIT_description>/config/sensor_kit_calibration.yaml` is not used.
 
-## 3. individual_parameter
+## 3. YOUR_AUTOWARE_INDIVIDUAL_PARAMS/individual_params
 
-The `individual_parameter` is where parameters referenced by `sensors.xacro` and `sensor_kit.xacro` are stored. As the name imply, it is intended to manage parameters for multiple individual instances.
+The `individual_params` package is where parameters referenced by `sensors.xacro` and `sensor_kit.xacro` are stored. As the name implies, it is intended to manage parameters for multiple individual instances.
 
 ### Introduction to Various Parameters
 
@@ -149,9 +222,9 @@ individual_params/
 +              └─ sensors_calibration.yaml
 ```
 
-## 4.YOUR_VEHICLE_launch
+## 5.YOUR_VEHICLE_launch/YOUR_VEHICLE_launch
 
-`YOUR_VEHICLE_launch` is where the launch file for starting the drive system devices is stored.
+The `YOUR_VEHICLE_launch` package is where the launch file for starting the drive system devices is stored.
 
 1. vehicle_interface.launch.xml (must be changed)
 
@@ -161,9 +234,9 @@ individual_params/
 
 If you are operating multiple vehicles, use the `vehicle_id` to switch to the corresponding configuration for each vehicle.
 
-## 5. YOUR_SENSOR_KIT_launch
+## 5. YOUR_SENSOR_KIT_launch/YOUR_SENSOR_KIT_launch
 
-`YOUR_SENSOR_KIT_launch` is where the launch files related to sensor startup are stored.
+The `YOUR_SENSOR_KIT_launch` package is where the launch files related to sensor startup are stored.
 
 1. sensing.launch.xml (must be changed)
 2. lidar.launch.xml (must be changed)

--- a/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
+++ b/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
@@ -14,10 +14,10 @@ Most of the packages within the Autoware meta-repository are designed to be vehi
 
 To create your own Autoware meta-repository, you can start by forking the [autowarefoundation/autoware](https://github.com/autowarefoundation/autoware) repository. For guidance on forking a repository, you can refer to [GitHub Docs](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
 
-
 ```bash
 git clone https://github.com/YOUR_NAME/autoware.git
 ```
+
 Note: If you set up multiple types of vehicles, adding a suffix like `autoware.vehicle_A` or `autoware.vehicle_B` is recommended.
 
 Then, you can create forks of different Autoware repositories that you might need to customize. Some of the packages you might need to customize include the "vehicle_description", the "sensor_kit_description", `individual_params` and the "vehicle-interface" packages. Said packages contain information and parameters about your vehicle dimensions and sensor configuration.
@@ -27,7 +27,6 @@ Note that [Autoware](https://github.com/autowarefoundation/autoware) contains sa
 - [creating-vehicle-and-sensor-description packages](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description)
 - [creating-vehicle-interface-package](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-interface-package/creating-a-vehicle-interface-for-an-ackermann-kinematic-model/)
 - [customizing-for-differential-drive-model](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-interface-package/customizing-for-differential-drive-model/)
-
 
 ### 2. Referencing a custom repository on your Autoware meta-repository
 
@@ -55,10 +54,10 @@ Note: VCS stands for Version Control System, such as Git or Subversion.
 
 Once you have forked or created your custom Autoware repositories and added their references to `autoware.repos`, you can import them to your autoware project src folder in a similar manner to that of the [Autoware source installation guide](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/#how-to-set-up-a-workspace) by:
 
-   ```bash
-   cd autoware.your_vehicle_name
-   mkdir src
-   vcs import src < autoware.repos
-   ```
-then you can build and test your packages.
+```bash
+cd autoware.your_vehicle_name
+mkdir src
+vcs import src < autoware.repos
+```
 
+then you can build and test your packages.

--- a/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
+++ b/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
@@ -59,4 +59,5 @@ cd autoware.your_vehicle_name
 mkdir src
 vcs import src < autoware.repos
 ```
+
 After importing your custom repos into your project's `src/` folder, you can build and test your autoware implementation as explained by the [Autoware source installation guide](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/#how-to-set-up-a-workspace).

--- a/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
+++ b/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
@@ -8,7 +8,7 @@ A meta-repository is a repository that contains references or information about 
 
 ## How to create and customize your autoware meta-repository
 
-### 1. Create autoware repository
+### 1. Create your autoware repository
 
 Most of the packages within the Autoware meta-repository are designed to be vehicle-agnostic, meaning they are not tied to any specific vehicle type. However, when integrating Autoware with your vehicle, it becomes necessary to create vehicle-specific packages tailored to your specific vehicle's implementation. Once you've developed these vehicle-specific packages, you can incorporate references to them within your Autoware meta-repository. This allows you to combine and utilize Autoware's vehicle-agnostic packages with your custom, vehicle-specific packages.
 
@@ -18,20 +18,22 @@ To create your own Autoware meta-repository, you can start by forking the [autow
 ```bash
 git clone https://github.com/YOUR_NAME/autoware.git
 ```
+Note: If you set up multiple types of vehicles, adding a suffix like `autoware.vehicle_A` or `autoware.vehicle_B` is recommended.
 
-If you set up multiple types of vehicles, adding a suffix like `autoware.vehicle_A` or `autoware.vehicle_B` is recommended
+Then, you can create forks of different Autoware repositories that you might need to customize. Some of the packages you might need to customize include the "vehicle_description", the "sensor_kit_description", `individual_params` and the "vehicle-interface" packages. Said packages contain information and parameters about your vehicle dimensions and sensor configuration.
 
-### 2. Customize your autoware.repos for your environment
+Note that [Autoware](https://github.com/autowarefoundation/autoware) contains sample packages that you may use as templates (sample_vehicle_description, sample_sensort_kit, and individual_parameters packages, for example). But you may also need to create a package from scratch to define as autoware-vehicle interface. For more information, please take a look on the following guides:
 
-You need to customize `autoware.repos` for your own vehicle's Autoware.
+- [creating-vehicle-and-sensor-description packages](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description)
+- [creating-vehicle-interface-package](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-interface-package/creating-a-vehicle-interface-for-an-ackermann-kinematic-model/)
+- [customizing-for-differential-drive-model](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-interface-package/customizing-for-differential-drive-model/)
 
-For example, if you want to customize the parameters in your `individual_params` or `autoware_launch` package to fit your vehicle, you can modify the configuration of each package and use them accordingly.
 
-Please edit the parameters in Autoware's `autoware_individual_params` and `autoware_launch` packages to match your vehicle's specific requirements, as these packages provide sample parameters and may not be tailored to your vehicle by default.
+### 2. Referencing a custom repository on your Autoware meta-repository
 
-If you want to fork `autoware_individual_params` and make modifications, it would be as follows:
+Once you create a custom package that needs to be referenced by your autoware meta-repository, it should be referenced in your `autoware.repos` file.
 
-Example: If you fork `individual_params` and rename `autoware_individual_params.vehicle_A`:
+As an Example: If you fork `individual_params` and rename it to `autoware_individual_params.vehicle_A` you would make the following changes to your `autoware.repos` file on your autoware meta-repository fork:
 
 ```diff
 - param/autoware_individual_params:
@@ -44,15 +46,19 @@ Example: If you fork `individual_params` and rename `autoware_individual_params.
 +   version: main
 ```
 
-Please refer to the following documentation link for instructions on how to create and customize each `vehicle_interface`:
-
-- [creating-vehicle-and-sensor-description](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description)
-- [creating-vehicle-interface-package](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-interface-package/creating-a-vehicle-interface-for-an-ackermann-kinematic-model/)
-- [customizing-for-differential-drive-model](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-interface-package/customizing-for-differential-drive-model/)
-
-Please remember to add all your custom packages, such as interfaces and descriptions, to your `autoware.repos` to ensure that your packages are properly included and managed within the Autoware repository.
+### 3. Setting up your workspace
 
 By using Ansible and VCS, you can automatically set up your Autoware.
 `autoware.repos` file manages the configuration of multiple repositories.
 
 Note: VCS stands for Version Control System, such as Git or Subversion.
+
+Once you have forked or created your custom Autoware repositories and added their references to `autoware.repos`, you can import them to your autoware project src folder in a similar manner to that of the [Autoware source installation guide](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/#how-to-set-up-a-workspace) by:
+
+   ```bash
+   cd autoware.your_vehicle_name
+   mkdir src
+   vcs import src < autoware.repos
+   ```
+then you can build and test your packages.
+

--- a/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
+++ b/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
@@ -8,9 +8,13 @@ A meta-repository is a repository that contains references or information about 
 
 ## How to Create and Customize Your Autoware Meta-Repository
 
-### 1. Create Your Autoware Repository
+### 1. Why Make Your Own Autoware-Meta-Repository?
 
-Most of the packages within the Autoware meta-repository are designed to be vehicle-agnostic, meaning they are not tied to any specific vehicle type. However, when integrating Autoware with your vehicle, it becomes necessary to create vehicle-specific packages tailored to your specific vehicle's implementation. Once you've developed these vehicle-specific packages, you can incorporate references to them within your Autoware meta-repository. This allows you to combine and utilize Autoware's vehicle-agnostic packages with your custom, vehicle-specific packages.
+Most of the packages within the Autoware meta-repository are designed to be vehicle-agnostic, meaning they are not tied to any specific vehicle type.
+
+However, when integrating Autoware with your vehicle, it becomes necessary to create vehicle-specific packages tailored to your specific vehicle's implementation. Once you've developed these vehicle-specific packages, you can incorporate references to them within your Autoware meta-repository. This allows you to combine and utilize Autoware's vehicle-agnostic packages with your custom, vehicle-specific packages.
+
+### 2. Create Your Autoware Repository
 
 To create your own Autoware meta-repository, you can start by forking the [autowarefoundation/autoware](https://github.com/autowarefoundation/autoware) repository. For guidance on forking a repository, you can refer to [GitHub Docs](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
 
@@ -20,15 +24,17 @@ git clone https://github.com/YOUR_NAME/autoware.git
 
 Note: If you set up multiple types of vehicles, adding a suffix like `autoware.vehicle_A` or `autoware.vehicle_B` is recommended.
 
-Then, you can create forks of different Autoware repositories that you might need to customize. Some of the packages you might need to customize include the "vehicle_description", the "sensor_kit_description", `individual_params` and the "vehicle-interface" packages. Said packages contain information and parameters about your vehicle dimensions and sensor configuration.
+Then, you can create forks of different Autoware repositories that you might need to customize. Some of the repositories you might need to customize include the `vehicle_description`, the `sensor_kit_description`, `individual_params` and the `vehicle-interface` packages. Said repositories contain packages with information and parameters about your vehicle dimensions and sensor configuration.
 
-Note that [Autoware](https://github.com/autowarefoundation/autoware) contains sample packages that you may use as templates (e.g., sample_vehicle_description, sample_sensor_kit, and individual_parameters packages). However, you may also need to create a package from scratch to define an Autoware vehicle interface. For more information, please take a look at the following guides:
+### 3. Create Your Custom Vehicle Repositories and Packages
+
+[Autoware](https://github.com/autowarefoundation/autoware) references sample repositories with sample packages that you may use as templates (e.g., sample_vehicle_description, sample_sensor_kit, and individual_parameters packages). However, you may also need to create a package and repository from scratch to define an Autoware-vehicle interface. For more information, please take a look at the following guides:
 
 - [creating-vehicle-and-sensor-description packages](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description)
 - [creating-vehicle-interface-package](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-interface-package/creating-a-vehicle-interface-for-an-ackermann-kinematic-model/)
 - [customizing-for-differential-drive-model](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-interface-package/customizing-for-differential-drive-model/)
 
-### 2. Referencing a custom repository on your Autoware meta-repository
+### 4. Referencing a Custom Repository on Your Autoware Meta-Repository
 
 Once you create a custom package that needs to be referenced by your autoware meta-repository, it should be referenced in your `autoware.repos` file.
 
@@ -45,7 +51,7 @@ As an Example: If you fork `individual_params` and rename it to `autoware_indivi
 +   version: main
 ```
 
-### 3. Setting up your workspace
+### 5. Setting up your workspace
 
 By using Ansible and VCS, you can automatically set up your Autoware.
 `autoware.repos` file manages the configuration of multiple repositories.

--- a/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
+++ b/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
@@ -52,12 +52,11 @@ By using Ansible and VCS, you can automatically set up your Autoware.
 
 Note: VCS stands for Version Control System, such as Git or Subversion.
 
-Once you have forked or created your custom Autoware repositories and added their references to `autoware.repos`, you can import them to your autoware project src folder in a similar manner to that of the [Autoware source installation guide](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/#how-to-set-up-a-workspace) by:
+Once you have forked or created your custom Autoware repositories and added their references to `autoware.repos`, you can import them to your autoware project src folder in a similar manner to that of the [Autoware source installation guide](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/#how-to-set-up-a-workspace) by executing the following commands:
 
 ```bash
 cd autoware.your_vehicle_name
 mkdir src
 vcs import src < autoware.repos
 ```
-
-then you can build and test your packages.
+After importing your custom repos into your project's `src/` folder, you can build and test your autoware implementation as explained by the [Autoware source installation guide](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/#how-to-set-up-a-workspace).

--- a/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
+++ b/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
@@ -1,14 +1,14 @@
-# Creating an Autoware meta-repository
+# Creating an Autoware Meta-Repository
 
-## What is Meta-repository?
+## What is a Meta-Repository?
 
 A meta-repository is a repository that contains references or information about other repositories. It serves as a central point of reference or coordination for multiple repositories.
 
 [Autoware](https://github.com/autowarefoundation/autoware) is a meta-repository. It contains references to several other repositories that provide source code used to realize autonomous driving.
 
-## How to create and customize your autoware meta-repository
+## How to Create and Customize Your Autoware Meta-Repository
 
-### 1. Create your autoware repository
+### 1. Create Your Autoware Repository
 
 Most of the packages within the Autoware meta-repository are designed to be vehicle-agnostic, meaning they are not tied to any specific vehicle type. However, when integrating Autoware with your vehicle, it becomes necessary to create vehicle-specific packages tailored to your specific vehicle's implementation. Once you've developed these vehicle-specific packages, you can incorporate references to them within your Autoware meta-repository. This allows you to combine and utilize Autoware's vehicle-agnostic packages with your custom, vehicle-specific packages.
 
@@ -22,7 +22,7 @@ Note: If you set up multiple types of vehicles, adding a suffix like `autoware.v
 
 Then, you can create forks of different Autoware repositories that you might need to customize. Some of the packages you might need to customize include the "vehicle_description", the "sensor_kit_description", `individual_params` and the "vehicle-interface" packages. Said packages contain information and parameters about your vehicle dimensions and sensor configuration.
 
-Note that [Autoware](https://github.com/autowarefoundation/autoware) contains sample packages that you may use as templates (sample_vehicle_description, sample_sensort_kit, and individual_parameters packages, for example). But you may also need to create a package from scratch to define as autoware-vehicle interface. For more information, please take a look on the following guides:
+Note that [Autoware](https://github.com/autowarefoundation/autoware) contains sample packages that you may use as templates (e.g., sample_vehicle_description, sample_sensor_kit, and individual_parameters packages). However, you may also need to create a package from scratch to define an Autoware vehicle interface. For more information, please take a look at the following guides:
 
 - [creating-vehicle-and-sensor-description packages](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-description/creating-vehicle-and-sensor-description)
 - [creating-vehicle-interface-package](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-interface-package/creating-a-vehicle-interface-for-an-ackermann-kinematic-model/)

--- a/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
+++ b/docs/how-to-guides/integrating-autoware/creating-your-autoware-meta-repository/creating-autoware-meta-repository.md
@@ -1,23 +1,19 @@
-# Creating Autoware meta-repository
+# Creating an Autoware meta-repository
 
 ## What is Meta-repository?
 
-A meta-repository is a repository that manages multiple repositories, and [Autoware](https://github.com/autowarefoundation/autoware) is one of them.
-It serves as a centralized control point for referencing, configuring, and versioning other repositories.
+A meta-repository is a repository that contains references or information about other repositories. It serves as a central point of reference or coordination for multiple repositories.
 
-By using Ansible and VCS, you can automatically set up your Autoware.
-`autoware.repos` file manages the configuration of multiple repositories.
-
-Note: VCS stands for Version Control System, such as Git or Subversion.
+[Autoware](https://github.com/autowarefoundation/autoware) is a meta-repository. It contains references to several other repositories that provide source code used to realize autonomous driving.
 
 ## How to create and customize your autoware meta-repository
 
 ### 1. Create autoware repository
 
-If you want to integrate Autoware into your vehicle, the first step is to create an Autoware meta-repository.
+Most of the packages within the Autoware meta-repository are designed to be vehicle-agnostic, meaning they are not tied to any specific vehicle type. However, when integrating Autoware with your vehicle, it becomes necessary to create vehicle-specific packages tailored to your specific vehicle's implementation. Once you've developed these vehicle-specific packages, you can incorporate references to them within your Autoware meta-repository. This allows you to combine and utilize Autoware's vehicle-agnostic packages with your custom, vehicle-specific packages.
 
-One easy way is to fork [autowarefoundation/autoware](https://github.com/autowarefoundation/autoware) and clone it.
-For how to fork a repository, refer to [GitHub Docs](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
+To create your own Autoware meta-repository, you can start by forking the [autowarefoundation/autoware](https://github.com/autowarefoundation/autoware) repository. For guidance on forking a repository, you can refer to [GitHub Docs](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
+
 
 ```bash
 git clone https://github.com/YOUR_NAME/autoware.git
@@ -55,3 +51,8 @@ Please refer to the following documentation link for instructions on how to crea
 - [customizing-for-differential-drive-model](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-interface-package/customizing-for-differential-drive-model/)
 
 Please remember to add all your custom packages, such as interfaces and descriptions, to your `autoware.repos` to ensure that your packages are properly included and managed within the Autoware repository.
+
+By using Ansible and VCS, you can automatically set up your Autoware.
+`autoware.repos` file manages the configuration of multiple repositories.
+
+Note: VCS stands for Version Control System, such as Git or Subversion.


### PR DESCRIPTION
## Description

This is a set of (ongoing) recommendations and improvements to the Autoware integration guide based on my own experience integrating Autoware on a robotized vehicle. I believe these changes might make it easier for a new user to use Autoware on their vehicle.

The changes include:
-Improved description of a meta-repository and how to set an autoware meta-repo.
-Clearer explanation of the sample_repository-sample_package relationship and structure.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
