### PR TITLE
docs(sensing): update lidar data field requirement

### DIFF
--- a/docs/design/autoware-architecture/sensing/data-types/point-cloud.md
+++ b/docs/design/autoware-architecture/sensing/data-types/point-cloud.md
@@ -47,7 +47,7 @@ In the ideal case, the driver is expected to output a point cloud with the `Poin
 | `C` (channel)     | `UINT16`  | `false` | Vertical channel id of the laser that measured the point                 |
 | `A` (azimuth)     | `FLOAT32` | `true`  | `atan2(Y, X)`, Horizontal angle from the front of the lidar to the point |
 | `D` (distance)    | `FLOAT32` | `true`  | `hypot(X, Y, Z)`, Euclidean distance of the point to lidar               |
-| `T` (time)        | `FLOAT64` | `false` | Seconds passed since the time of the header when this point was measured |
+| `T` (time stamp)  | `FLOAT64` | `false` | Seconds passed since the time of the header when this point was measured |
 
 !!! note
 
@@ -180,7 +180,7 @@ For solid state lidars that have lines, assign row number as the channel id.
 
 For petal pattern lidars, you can keep channel 0.
 
-### Time
+### Time stamp
 
 In lidar point clouds, each point measurement can have its individual time stamp.
 This information can be used to eliminate the motion blur that is caused by the movement of the lidar during the scan.
@@ -204,7 +204,7 @@ The header of the point cloud message is expected to have the time of the earlie
 
     **More info at:** https://github.com/ros2/rcl_interfaces/issues/85
 
-#### Individual point time
+#### Individual point time stamp
 
 Each `PointXYZIRCT` point type has the `T` field for representing the seconds passed since the first-shot point of the point cloud.
 

--- a/docs/design/autoware-architecture/sensing/data-types/point-cloud.md
+++ b/docs/design/autoware-architecture/sensing/data-types/point-cloud.md
@@ -37,17 +37,17 @@ It is recommended that these modules are used in a single container as component
 
 In the ideal case, the driver is expected to output a point cloud with the `PointXYZIRCADT` point type.
 
-| name              | datatype  | derived | description                                                                  |
-| ----------------- | --------- | ------- | ---------------------------------------------------------------------------- |
-| `X`               | `FLOAT32` | `false` | X position                                                                   |
-| `Y`               | `FLOAT32` | `false` | Y position                                                                   |
-| `Z`               | `FLOAT32` | `false` | Z position                                                                   |
-| `I` (intensity)   | `UINT8`   | `false` | Measured reflectivity, intensity of the point                                |
-| `R` (return type) | `UINT8`   | `false` | Laser return type for dual return lidars                                     |
-| `C` (channel)     | `UINT16`  | `false` | Vertical channel id of the laser that measured the point                     |
-| `A` (azimuth)     | `FLOAT32` | `true`  | `atan2(Y, X)`, Horizontal angle from the front of the lidar to the point     |
-| `D` (distance)    | `FLOAT32` | `true`  | `hypot(X, Y, Z)`, Euclidean distance of the point to lidar                   |
-| `T` (time)        | `UINT32`  | `false` | Nanoseconds passed since the time of the header when this point was measured |
+| name              | datatype  | derived | description                                                              |
+| ----------------- | --------- | ------- | ------------------------------------------------------------------------ |
+| `X`               | `FLOAT32` | `false` | X position                                                               |
+| `Y`               | `FLOAT32` | `false` | Y position                                                               |
+| `Z`               | `FLOAT32` | `false` | Z position                                                               |
+| `I` (intensity)   | `FLOAT32` | `false` | Measured reflectivity, intensity of the point                            |
+| `R` (return type) | `UINT8`   | `false` | Laser return type for dual return lidars                                 |
+| `C` (channel)     | `UINT16`  | `false` | Vertical channel id of the laser that measured the point                 |
+| `A` (azimuth)     | `FLOAT32` | `true`  | `atan2(Y, X)`, Horizontal angle from the front of the lidar to the point |
+| `D` (distance)    | `FLOAT32` | `true`  | `hypot(X, Y, Z)`, Euclidean distance of the point to lidar               |
+| `T` (time)        | `FLOAT64` | `false` | Seconds passed since the time of the header when this point was measured |
 
 !!! note
 
@@ -206,11 +206,6 @@ The header of the point cloud message is expected to have the time of the earlie
 
 #### Individual point time
 
-Each `PointXYZIRCT` point type has the `T` field for representing the nanoseconds passed since the first-shot point of the point cloud.
+Each `PointXYZIRCT` point type has the `T` field for representing the seconds passed since the first-shot point of the point cloud.
 
-To calculate exact time each point was shot, the `T` nanoseconds are added to the header time.
-
-!!! note
-
-    The `T` field is `uint32` type. The largest value it can represent is 2^32 nanoseconds, which equates to roughly
-    4.29 seconds. Usual point clouds don't last more than 100ms for full cycle. So this field should be enough.
+To calculate exact time each point was shot, the `T` seconds are added to the header time.


### PR DESCRIPTION
## Description

* I noticed that the lidar data filed types presented on this page do not match the actual ones. So, I fixed them.

|type| before | after|reference
|--|--|--|--|
|T(time)|FLOAT32|FLOAT64| [distortion_corrector.cpp](https://github.com/autowarefoundation/autoware.universe/blob/a3e87cc537554e18732c0ebd86ae39d7b9d14a85/sensing/pointcloud_preprocessor/src/distortion_corrector/distortion_corrector.cpp#L195)|
|I(intensity)|UINT8|FLOAT32| [ring_outlier_filter.cpp](https://github.com/autowarefoundation/autoware.universe/blob/a3e87cc537554e18732c0ebd86ae39d7b9d14a85/sensing/pointcloud_preprocessor/src/outlier_filter/ring_outlier_filter_nodelet.cpp#L96)|

* Also, I found some nodes require the time_stamp as *seconds* rather than *nanoseconds*.
e.g. [distortion_corrector.cpp](https://github.com/autowarefoundation/autoware.universe/blob/a3e87cc537554e18732c0ebd86ae39d7b9d14a85/sensing/pointcloud_preprocessor/src/distortion_corrector/distortion_corrector.cpp#L201), [nebula_common.cpp](https://github.com/tier4/nebula/blob/476224d5844c24721030da176d9def615fa9c43a/nebula_common/src/nebula_common.cpp#L63)

* This is trivial, but the default T's name is `time_stamp`, not `time`, so I corrected some notations.
e.g. [utility/utilities.cpp](https://github.com/autowarefoundation/autoware.universe/blob/a3e87cc537554e18732c0ebd86ae39d7b9d14a85/sensing/pointcloud_preprocessor/src/utility/utilities.cpp#L232), [nebula_common/point_types.hpp](https://github.com/tier4/nebula/blob/476224d5844c24721030da176d9def615fa9c43a/nebula_common/include/nebula_common/point_types.hpp#L54)

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
