### PR TITLE
docs(localization): add note for non-NDT users

### DIFF
--- a/docs/how-to-guides/integrating-autoware/launch-autoware/localization/index.md
+++ b/docs/how-to-guides/integrating-autoware/launch-autoware/localization/index.md
@@ -97,12 +97,13 @@ you can add this argument on `tier4_localization_component.launch.xml` launch fi
 **Note:** Gyro odometer input topic provided from velocity converter package. This package will be launched at sensor_kit. For more information,
 please check [velocity converter package](https://github.com/autowarefoundation/autoware.universe/tree/main/sensing/vehicle_velocity_converter).
 
-## Note when using non NDT pose estiamtor
+## Note when using non NDT pose estimator
 
 !!! note
-Since NDT is currently the most often used pose_estiamtor, the NDT diagnostics are registered for monitoring by default.
-When using a pose_estimator othen than NDT, NDT diagnostics will always be marked as stale, causing the system to enter a safe_fault state.
-Depending on the parameters of emergencies, this could escalate to a full emergency, preventing autonomous driving.
+
+    Since NDT is currently the most often used pose_estimator , the NDT diagnostics are registered for monitoring by default.
+    When using a pose_estimator other than NDT, NDT diagnostics will always be marked as stale, causing the system to enter a safe_fault state.
+    Depending on the parameters of emergencies, this could escalate to a full emergency, preventing autonomous driving.
 
 To work around this, please modify the configuration file of the system_error_monitor.
 In the [system_error_monitor.param.yaml](https://github.com/autowarefoundation/autoware.universe/blob/main/system/system_error_monitor/config/system_error_monitor.param.yaml) file, `/autoware/localization/performance_monitoring/matching_score` represents the aggregated diagnostics for NDT.

--- a/docs/how-to-guides/integrating-autoware/launch-autoware/localization/index.md
+++ b/docs/how-to-guides/integrating-autoware/launch-autoware/localization/index.md
@@ -100,9 +100,9 @@ please check [velocity converter package](https://github.com/autowarefoundation/
 ## Note when using non NDT pose estiamtor
 
 !!! note
-    Since NDT is currently the most often used pose_estiamtor, the NDT diagnostics are registered for monitoring by default.
-    When using a pose_estimator othen than NDT, NDT diagnostics will always be marked as stale, causing the system to enter a safe_fault state.
-    Depending on the parameters of emergencies, this could escalate to a full emergency, preventing autonomous driving.
+Since NDT is currently the most often used pose_estiamtor, the NDT diagnostics are registered for monitoring by default.
+When using a pose_estimator othen than NDT, NDT diagnostics will always be marked as stale, causing the system to enter a safe_fault state.
+Depending on the parameters of emergencies, this could escalate to a full emergency, preventing autonomous driving.
 
 To work around this, please modify the configuration file of the system_error_monitor.
 In the [system_error_monitor.param.yaml](https://github.com/autowarefoundation/autoware.universe/blob/main/system/system_error_monitor/config/system_error_monitor.param.yaml) file, `/autoware/localization/performance_monitoring/matching_score` represents the aggregated diagnostics for NDT.

--- a/docs/how-to-guides/integrating-autoware/launch-autoware/localization/index.md
+++ b/docs/how-to-guides/integrating-autoware/launch-autoware/localization/index.md
@@ -96,3 +96,15 @@ you can add this argument on `tier4_localization_component.launch.xml` launch fi
 
 **Note:** Gyro odometer input topic provided from velocity converter package. This package will be launched at sensor_kit. For more information,
 please check [velocity converter package](https://github.com/autowarefoundation/autoware.universe/tree/main/sensing/vehicle_velocity_converter).
+
+## Note when using non NDT pose estiamtor
+
+!!! note
+    Since NDT is currently the most often used pose_estiamtor, the NDT diagnostics are registered for monitoring by default.
+    When using a pose_estimator othen than NDT, NDT diagnostics will always be marked as stale, causing the system to enter a safe_fault state.
+    Depending on the parameters of emergencies, this could escalate to a full emergency, preventing autonomous driving.
+
+To work around this, please modify the configuration file of the system_error_monitor.
+In the [system_error_monitor.param.yaml](https://github.com/autowarefoundation/autoware.universe/blob/main/system/system_error_monitor/config/system_error_monitor.param.yaml) file, `/autoware/localization/performance_monitoring/matching_score` represents the aggregated diagnostics for NDT.
+To prevent emergencies even when NDT is not launched, remove this entry from the configuration.
+Note that the module name `/performance_monitoring/matching_score` is specified in [diagnostics_aggregator/localization.param.yaml](https://github.com/autowarefoundation/autoware.universe/blob/main/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml).


### PR DESCRIPTION
## Description

I added a note to users who use pose_estimator other than NDT.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
