### PR TITLE
docs: add the carla simulator page under digital twin

### DIFF
--- a/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/.pages
+++ b/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/.pages
@@ -1,3 +1,4 @@
 nav:
   - awsim-tutorial.md
   - MORAI_Sim-tutorial.md
+  - carla-tutorial.md

--- a/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/carla-tutorial.md
+++ b/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/carla-tutorial.md
@@ -2,7 +2,7 @@
 
 [CARLA](https://carla.org) is a famous open-source simulator for the autonomous driving research.
 Now there is no official support to Autoware.universe, but some projects from communities support it.
-The docoment is to list these projects for anyone who wants to run Autoware with Carla.
+The document is to list these projects for anyone who wants to run Autoware with Carla.
 You can report issues to each project if there is any problem.
 
 ## Project lists

--- a/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/carla-tutorial.md
+++ b/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/carla-tutorial.md
@@ -5,13 +5,30 @@ Now there is no official support to Autoware.universe, but some projects from co
 The document is to list these projects for anyone who wants to run Autoware with Carla.
 You can report issues to each project if there is any problem.
 
-## Project lists
+## Project lists (In alphabetical order)
 
-### Zenoh Carla Bridge
+### carla_autoware_bridge
+
+An addition package to `carla_ros_bridge` to connect CARLA simulator to Autoware Universe software.
+
+- Project Link: [carla_autoware_bridge](https://github.com/Robotics010/carla_autoware_bridge)
+- Tutorial: [https://github.com/Robotics010/carla_autoware_bridge/blob/master/getting-started.md](https://github.com/Robotics010/carla_autoware_bridge/blob/master/getting-started.md)
+
+
+### open_planner
+
+Integrated open source planner and related tools for autonomous navigation of autonomous vehicle and mobile robots
+
+- Project Link: [open_planner](https://github.com/ZATiTech/open_planner/tree/humble)
+- Tutorial: [https://github.com/ZATiTech/open_planner/blob/humble/op_carla_bridge/README.md](https://github.com/ZATiTech/open_planner/blob/humble/op_carla_bridge/README.md)
+
+### zenoh_carla_bridge
 
 The project is mainly for controlling multiple vehicles in Carla.
-It uses Zenoh to bridge the Autoware and Carla and is able to distinguish different messages for different vehicles.
-Feel free to ask questions and report issues on [GitHub](https://github.com/evshary/autoware_carla_launch/issues).
+It uses [Zenoh](https://zenoh.io/) to bridge the Autoware and Carla and is able to distinguish different messages for different vehicles.
+Feel free to ask questions and report issues to [autoware_carla_launch](https://github.com/evshary/autoware_carla_launch).
 
-- Project Link: [autoware_carla_launch](https://github.com/evshary/autoware_carla_launch)
+- Project Link: 
+  - [autoware_carla_launch](https://github.com/evshary/autoware_carla_launch): Integrated environment to run the bridge and Autoware easily.
+  - [zenoh_carla_bridge](https://github.com/evshary/zenoh_carla_bridge): The bridge implementation.
 - Tutorial: [Running Multiple Autoware-Powered Vehicles in Carla using Zenoh](https://autoware.org/running-multiple-autoware-powered-vehicles-in-carla-using-zenoh)

--- a/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/carla-tutorial.md
+++ b/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/carla-tutorial.md
@@ -13,5 +13,5 @@ The project is mainly for controlling multiple vehicles in Carla.
 It uses Zenoh to bridge the Autoware and Carla and is able to distinguish different messages for different vehicles.
 Feel free to ask questions and report issues on [GitHub](https://github.com/evshary/autoware_carla_launch/issues).
 
-* Project Link: [autoware_carla_launch](https://github.com/evshary/autoware_carla_launch)
-* Tutorial: [Running Multiple Autoware-Powered Vehicles in Carla using Zenoh](https://autoware.org/running-multiple-autoware-powered-vehicles-in-carla-using-zenoh)
+- Project Link: [autoware_carla_launch](https://github.com/evshary/autoware_carla_launch)
+- Tutorial: [Running Multiple Autoware-Powered Vehicles in Carla using Zenoh](https://autoware.org/running-multiple-autoware-powered-vehicles-in-carla-using-zenoh)

--- a/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/carla-tutorial.md
+++ b/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/carla-tutorial.md
@@ -1,0 +1,17 @@
+# CARLA simulator
+
+[CARLA](https://carla.org) is a famous open-source simulator for the autonomous driving research.
+Now there is no official support to Autoware.universe, but some projects from communities support it.
+The docoment is to list these projects for anyone who wants to run Autoware with Carla.
+You can report issues to each project if there is any problem.
+
+# Project lists
+
+## Zenoh Carla Bridge
+
+The project is mainly for controlling multiple vehicles in Carla.
+It uses Zenoh to bridge the Autoware and Carla and is able to distinguish different messages for different vehicles.
+Feel free to ask questions and report issues on [GitHub](https://github.com/evshary/autoware_carla_launch/issues).
+
+* Project Link: [autoware_carla_launch](https://github.com/evshary/autoware_carla_launch)
+* Tutorial: [Running Multiple Autoware-Powered Vehicles in Carla using Zenoh](https://autoware.org/running-multiple-autoware-powered-vehicles-in-carla-using-zenoh)

--- a/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/carla-tutorial.md
+++ b/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/carla-tutorial.md
@@ -14,7 +14,6 @@ An addition package to `carla_ros_bridge` to connect CARLA simulator to Autoware
 - Project Link: [carla_autoware_bridge](https://github.com/Robotics010/carla_autoware_bridge)
 - Tutorial: [https://github.com/Robotics010/carla_autoware_bridge/blob/master/getting-started.md](https://github.com/Robotics010/carla_autoware_bridge/blob/master/getting-started.md)
 
-
 ### open_planner
 
 Integrated open source planner and related tools for autonomous navigation of autonomous vehicle and mobile robots
@@ -28,7 +27,7 @@ The project is mainly for controlling multiple vehicles in Carla.
 It uses [Zenoh](https://zenoh.io/) to bridge the Autoware and Carla and is able to distinguish different messages for different vehicles.
 Feel free to ask questions and report issues to [autoware_carla_launch](https://github.com/evshary/autoware_carla_launch).
 
-- Project Link: 
+- Project Link:
   - [autoware_carla_launch](https://github.com/evshary/autoware_carla_launch): Integrated environment to run the bridge and Autoware easily.
   - [zenoh_carla_bridge](https://github.com/evshary/zenoh_carla_bridge): The bridge implementation.
 - Tutorial: [Running Multiple Autoware-Powered Vehicles in Carla using Zenoh](https://autoware.org/running-multiple-autoware-powered-vehicles-in-carla-using-zenoh)

--- a/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/carla-tutorial.md
+++ b/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/carla-tutorial.md
@@ -5,9 +5,9 @@ Now there is no official support to Autoware.universe, but some projects from co
 The docoment is to list these projects for anyone who wants to run Autoware with Carla.
 You can report issues to each project if there is any problem.
 
-# Project lists
+## Project lists
 
-## Zenoh Carla Bridge
+### Zenoh Carla Bridge
 
 The project is mainly for controlling multiple vehicles in Carla.
 It uses Zenoh to bridge the Autoware and Carla and is able to distinguish different messages for different vehicles.


### PR DESCRIPTION
## Description

Add the Carla simulator page, which includes several projects able to bridge Autoware and Carla.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
