### PR TITLE
docs(ad-api): release v1.1.0

### DIFF
--- a/docs/design/autoware-interfaces/ad-api/.pages
+++ b/docs/design/autoware-interfaces/ad-api/.pages
@@ -1,5 +1,6 @@
 nav:
   - index.md
-  - features
+  - release.md
   - list
   - types
+  - features

--- a/docs/design/autoware-interfaces/ad-api/features/routing.md
+++ b/docs/design/autoware-interfaces/ad-api/features/routing.md
@@ -25,10 +25,11 @@ There are two ways to set the route. The one is a generic method that uses pose,
 | ARRIVED  | The vehicle has arrived at the destination.        |
 | CHANGING | Trying to change the route. Not implemented yet.   |
 
-## Goal modification
+## Options
 
-Autoware tries to look for an alternate goal when goal is unreachable (e.g., when there is an obstacle on the given goal). When setting a route from the API, applications can choose whether they allow Autoware to adjust goal pose in such situation. When set false, Autoware may get stuck until the given goal becomes reachable.
+The `set_route_points` and `set_route` APIs have route options that allow applications to choose several behaviors regarding route planning.
+See the sections below for supported options and details.
 
-| Option                  | Description                       |
-| ----------------------- | --------------------------------- |
-| allow_goal_modification | If true, allow goal modification. |
+### allow_goal_modification
+
+**[v1.1.0]** Autoware tries to look for an alternate goal when goal is unreachable (e.g., when there is an obstacle on the given goal). When setting a route from the API, applications can choose whether they allow Autoware to adjust goal pose in such situation. When set false, Autoware may get stuck until the given goal becomes reachable.

--- a/docs/design/autoware-interfaces/ad-api/list/api/fail_safe/mrm_state.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/fail_safe/mrm_state.md
@@ -1,6 +1,6 @@
 ---
 title: /api/fail_safe/mrm_state
-status: not released
+status: v1.1.0
 method: notification
 type:
   name: autoware_adapi_v1_msgs/msg/MrmState

--- a/docs/design/autoware-interfaces/ad-api/list/api/perception/objects.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/perception/objects.md
@@ -1,6 +1,6 @@
 ---
 title: /api/perception/objects
-status: v1.0.0
+status: not released
 method: realtime stream
 type:
   name: autoware_adapi_v1_msgs/msg/DynamicObjectArray

--- a/docs/design/autoware-interfaces/ad-api/list/api/vehicle/dimensions.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/vehicle/dimensions.md
@@ -1,6 +1,6 @@
 ---
 title: /api/vehicle/dimensions
-status: not released
+status: v1.1.0
 method: function call
 type:
   name: autoware_adapi_v1_msgs/srv/GetVehicleDimensions

--- a/docs/design/autoware-interfaces/ad-api/list/api/vehicle/kinematics.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/vehicle/kinematics.md
@@ -1,6 +1,6 @@
 ---
 title: /api/vehicle/kinematics
-status: not released
+status: v1.1.0
 method: realtime stream
 type:
   name: autoware_adapi_v1_msgs/msg/VehicleKinematics

--- a/docs/design/autoware-interfaces/ad-api/list/index.md
+++ b/docs/design/autoware-interfaces/ad-api/list/index.md
@@ -1,32 +1,34 @@
 # List of Autoware AD API
 
-- [/api/fail_safe/mrm_state](./api/fail_safe/mrm_state.md)
-- [/api/interface/version](./api/interface/version.md)
-- [/api/localization/initialization_state](./api/localization/initialization_state.md)
-- [/api/localization/initialize](./api/localization/initialize.md)
-- [/api/motion/accept_start](./api/motion/accept_start.md)
-- [/api/motion/state](./api/motion/state.md)
-- [/api/operation_mode/change_to_autonomous](./api/operation_mode/change_to_autonomous.md)
-- [/api/operation_mode/change_to_local](./api/operation_mode/change_to_local.md)
-- [/api/operation_mode/change_to_remote](./api/operation_mode/change_to_remote.md)
-- [/api/operation_mode/change_to_stop](./api/operation_mode/change_to_stop.md)
-- [/api/operation_mode/disable_autoware_control](./api/operation_mode/disable_autoware_control.md)
-- [/api/operation_mode/enable_autoware_control](./api/operation_mode/enable_autoware_control.md)
-- [/api/operation_mode/state](./api/operation_mode/state.md)
-- [/api/perception/objects](./api/perception/objects.md)
-- [/api/planning/cooperation/get_policies](./api/planning/cooperation/get_policies.md)
-- [/api/planning/cooperation/set_commands](./api/planning/cooperation/set_commands.md)
-- [/api/planning/cooperation/set_policies](./api/planning/cooperation/set_policies.md)
-- [/api/planning/steering_factors](./api/planning/steering_factors.md)
-- [/api/planning/velocity_factors](./api/planning/velocity_factors.md)
-- [/api/routing/clear_route](./api/routing/clear_route.md)
-- [/api/routing/route](./api/routing/route.md)
-- [/api/routing/set_route](./api/routing/set_route.md)
-- [/api/routing/set_route_points](./api/routing/set_route_points.md)
-- [/api/routing/state](./api/routing/state.md)
-- [/api/vehicle/dimensions](./api/vehicle/dimensions.md)
-- [/api/vehicle/doors/command](./api/vehicle/doors/command.md)
-- [/api/vehicle/doors/layout](./api/vehicle/doors/layout.md)
-- [/api/vehicle/doors/status](./api/vehicle/doors/status.md)
-- [/api/vehicle/kinematics](./api/vehicle/kinematics.md)
-- [/api/vehicle/status](./api/vehicle/status.md)
+| API                                                                                              | Release      |
+| ------------------------------------------------------------------------------------------------ | ------------ |
+| [/api/fail_safe/mrm_state](./api/fail_safe/mrm_state.md)                                         | not released |
+| [/api/interface/version](./api/interface/version.md)                                             | v1.0.0       |
+| [/api/localization/initialization_state](./api/localization/initialization_state.md)             | v1.0.0       |
+| [/api/localization/initialize](./api/localization/initialize.md)                                 | v1.0.0       |
+| [/api/motion/accept_start](./api/motion/accept_start.md)                                         | not released |
+| [/api/motion/state](./api/motion/state.md)                                                       | not released |
+| [/api/operation_mode/change_to_autonomous](./api/operation_mode/change_to_autonomous.md)         | v1.0.0       |
+| [/api/operation_mode/change_to_local](./api/operation_mode/change_to_local.md)                   | v1.0.0       |
+| [/api/operation_mode/change_to_remote](./api/operation_mode/change_to_remote.md)                 | v1.0.0       |
+| [/api/operation_mode/change_to_stop](./api/operation_mode/change_to_stop.md)                     | v1.0.0       |
+| [/api/operation_mode/disable_autoware_control](./api/operation_mode/disable_autoware_control.md) | v1.0.0       |
+| [/api/operation_mode/enable_autoware_control](./api/operation_mode/enable_autoware_control.md)   | v1.0.0       |
+| [/api/operation_mode/state](./api/operation_mode/state.md)                                       | v1.0.0       |
+| [/api/perception/objects](./api/perception/objects.md)                                           | not released |
+| [/api/planning/cooperation/get_policies](./api/planning/cooperation/get_policies.md)             | not released |
+| [/api/planning/cooperation/set_commands](./api/planning/cooperation/set_commands.md)             | not released |
+| [/api/planning/cooperation/set_policies](./api/planning/cooperation/set_policies.md)             | not released |
+| [/api/planning/steering_factors](./api/planning/steering_factors.md)                             | not released |
+| [/api/planning/velocity_factors](./api/planning/velocity_factors.md)                             | not released |
+| [/api/routing/clear_route](./api/routing/clear_route.md)                                         | v1.0.0       |
+| [/api/routing/route](./api/routing/route.md)                                                     | v1.0.0       |
+| [/api/routing/set_route](./api/routing/set_route.md)                                             | v1.0.0       |
+| [/api/routing/set_route_points](./api/routing/set_route_points.md)                               | v1.0.0       |
+| [/api/routing/state](./api/routing/state.md)                                                     | v1.0.0       |
+| [/api/vehicle/dimensions](./api/vehicle/dimensions.md)                                           | not released |
+| [/api/vehicle/doors/command](./api/vehicle/doors/command.md)                                     | not released |
+| [/api/vehicle/doors/layout](./api/vehicle/doors/layout.md)                                       | not released |
+| [/api/vehicle/doors/status](./api/vehicle/doors/status.md)                                       | not released |
+| [/api/vehicle/kinematics](./api/vehicle/kinematics.md)                                           | not released |
+| [/api/vehicle/status](./api/vehicle/status.md)                                                   | not released |

--- a/docs/design/autoware-interfaces/ad-api/list/index.md
+++ b/docs/design/autoware-interfaces/ad-api/list/index.md
@@ -2,7 +2,7 @@
 
 | API                                                                                              | Release      |
 | ------------------------------------------------------------------------------------------------ | ------------ |
-| [/api/fail_safe/mrm_state](./api/fail_safe/mrm_state.md)                                         | not released |
+| [/api/fail_safe/mrm_state](./api/fail_safe/mrm_state.md)                                         | v1.1.0       |
 | [/api/interface/version](./api/interface/version.md)                                             | v1.0.0       |
 | [/api/localization/initialization_state](./api/localization/initialization_state.md)             | v1.0.0       |
 | [/api/localization/initialize](./api/localization/initialize.md)                                 | v1.0.0       |
@@ -26,9 +26,9 @@
 | [/api/routing/set_route](./api/routing/set_route.md)                                             | v1.0.0       |
 | [/api/routing/set_route_points](./api/routing/set_route_points.md)                               | v1.0.0       |
 | [/api/routing/state](./api/routing/state.md)                                                     | v1.0.0       |
-| [/api/vehicle/dimensions](./api/vehicle/dimensions.md)                                           | not released |
+| [/api/vehicle/dimensions](./api/vehicle/dimensions.md)                                           | v1.1.0       |
 | [/api/vehicle/doors/command](./api/vehicle/doors/command.md)                                     | not released |
 | [/api/vehicle/doors/layout](./api/vehicle/doors/layout.md)                                       | not released |
 | [/api/vehicle/doors/status](./api/vehicle/doors/status.md)                                       | not released |
-| [/api/vehicle/kinematics](./api/vehicle/kinematics.md)                                           | not released |
+| [/api/vehicle/kinematics](./api/vehicle/kinematics.md)                                           | v1.1.0       |
 | [/api/vehicle/status](./api/vehicle/status.md)                                                   | not released |

--- a/docs/design/autoware-interfaces/ad-api/release.md
+++ b/docs/design/autoware-interfaces/ad-api/release.md
@@ -1,8 +1,13 @@
 # Release notes
 
-## v1.0.0
+## v1.1.0
 
-The first release of AD API. Added basic features to start autonomous driving.
+- [New] Add {{ link_ad_api('/api/fail_safe/mrm_state') }}
+- [New] Add {{ link_ad_api('/api/vehicle/dimensions') }}
+- [New] Add {{ link_ad_api('/api/vehicle/kinematics') }}
+- [Change] Add options to [the routing API](./features/routing.md)
+
+## v1.0.0
 
 - [New] Add [interface API](./features/interface.md)
 - [New] Add [localization API](./features/localization.md)

--- a/docs/design/autoware-interfaces/ad-api/release.md
+++ b/docs/design/autoware-interfaces/ad-api/release.md
@@ -1,0 +1,10 @@
+# Release notes
+
+## v1.0.0
+
+The first release of AD API. Added basic features to start autonomous driving.
+
+- [New] Add [interface API](./features/interface.md)
+- [New] Add [localization API](./features/localization.md)
+- [New] Add [routing API](./features/routing.md)
+- [New] Add [operation mode API](./features/operation_mode.md)

--- a/tools/autoware-interfaces/generate.py
+++ b/tools/autoware-interfaces/generate.py
@@ -91,6 +91,17 @@ def parse_rosidl_file(depends: set, visited: set, specs: dict, name: str):
             specs[name] = {"req": req, "res": res}
             specs[name] = {k: v for k, v in specs[name].items() if v}
 
+
+def tabulate(data, header):
+    widths = map(len, header)
+    for line in data:
+        widths = map(max, zip(map(len, line), widths))
+    widths = list(widths)
+    format = "| " + " | ".join(f"{{:{width}}}" for width in widths) + " |"
+    border = ["-" * width for width in widths]
+    return "\n".join(format.format(*line) for line in [header, border, *data])
+
+
 def main():
     # Create a list of data types used in adapi.
     adapi = Path("docs/design/autoware-interfaces/ad-api/list/api")
@@ -148,9 +159,11 @@ def main():
         path.write_text(text)
 
     ## Generate api list page.
-    text = "# List of Autoware AD API\n\n"
-    for title in sorted(page["title"] for page in pages):
-        text += f"- [{title}](.{title}.md)\n"
+    data = []
+    for page in sorted(pages, key=lambda page: page["title"]):
+        title = page["title"]
+        data.append([f"[{title}](.{title}.md)", page['status']])
+    text = "# List of Autoware AD API\n\n" + tabulate(data, ["API", "Release"]) + "\n"
     Path("docs/design/autoware-interfaces/ad-api/list/index.md").write_text(text)
 
     ## Generate api type page.


### PR DESCRIPTION
## Description

Update AD API documents for v1.1.0 release.
- Add release notes page
- Add first release version to API list page
- Add "[v1.1.0]" to route option section.
- Update release status of v1.1.0 APIs

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
