### PR TITLE
docs(installation): fix run.sh documentation

### DIFF
--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -113,11 +113,7 @@ Using the [Visual Studio Code](https://code.visualstudio.com/) with the [Remote 
 Get the Visual Studio Code's [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
 And reopen the workspace in the container by selecting `Remote-Containers: Reopen in Container` from the Command Palette (`F1`).
 
-By default, devcontainer assumes NVIDIA GPU support, you can change this by deleting these lines within `.devcontainer/devcontainer.json`:
-
-!!! warning
-
-    Under Construction
+You can choose Autoware or Autoware-cuda image to develop with or without CUDA support.
 
 ## Building Docker images from scratch
 

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -41,15 +41,15 @@ You can use `run.sh` to run the Autoware runtime container with the map data:
 ./docker/run.sh --map-path path_to_map_data
 ```
 
+For more launch options, you can append a custom launch command instead of using the default launch command `ros2 launch autoware_launch autoware.launch.xml`:
+
+```bash
+./docker/run.sh --map-path path_to_map_data ros2 launch autoware_launch autoware.launch.xml map_path:=/autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+```
+
 !!! info
 
     You can use `--no-nvidia` to run without NVIDIA GPU support, and `--headless` to run without display that means no RViz visualization.
-
-For more launch options you can edit the launch command with `--launch-cmd` option:
-
-```bash
-./docker/run.sh --map-path path_to_map_data --launch-cmd "ros2 launch autoware_launch autoware.launch.xml map_path:=/autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit"
-```
 
 #### Run the Autoware tutorials
 


### PR DESCRIPTION
## Description

Fix run.sh documentation that being used in the Open AD Kit.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
