### PR TITLE
docs(rosbag-replay-simulation): add warnings about timestamp discrepancies and pre-playback messages

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -5,6 +5,7 @@ MD024:
   siblings_only: true
 MD029:
   style: ordered
+MD030: false
 MD033: false
 MD041: false
 MD046: false

--- a/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
@@ -62,12 +62,16 @@
 
    ![after-autoware-launch](images/rosbag-replay/after-autoware-launch.png)
 
+   > ⚠️ It might happen that you see in the terminal some error and warning messages before playing the rosbag (next step) unit you play the rosbag and proper initialization occurs
+
 2. Play the sample rosbag file.
 
    ```sh
    source ~/autoware/install/setup.bash
    ros2 bag play ~/autoware_map/sample-rosbag/sample.db3 -r 0.2 -s sqlite3
    ```
+
+   > ⚠️ As the timestamp in the rosbag is different than the current timestamp in your system , Autoware will output in to the terminal some warning messages due to this timestamp mismatch 
 
    ![after-rosbag-play](images/rosbag-replay/after-rosbag-play.png)
 

--- a/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
@@ -62,9 +62,9 @@
 
    ![after-autoware-launch](images/rosbag-replay/after-autoware-launch.png)
 
-!!! warning
+   !!! warning
 
-You might encounter error and warning messages in the terminal before playing the `rosbag`. This is normal behavior. These should cease once the `rosbag` is played and proper initialization takes place
+    You might encounter error and warning messages in the terminal before playing the `rosbag`. This is normal behavior. These should cease once the `rosbag` is played and proper initialization takes place
 
 2. Play the sample rosbag file.
 
@@ -73,11 +73,12 @@ You might encounter error and warning messages in the terminal before playing th
    ros2 bag play ~/autoware_map/sample-rosbag/sample.db3 -r 0.2 -s sqlite3
    ```
 
-!!! warning
+   !!! warning
 
-Due to the discrepancy between the timestamp in the `rosbag` and the current system timestamp, Autoware may generate warning messages in the terminal alerting to this mismatch. This is normal behavior.
-
-![after-rosbag-play](images/rosbag-replay/after-rosbag-play.png)
+    Due to the discrepancy between the timestamp in the `rosbag` and the current system timestamp, Autoware may generate warning messages in the terminal alerting to this mismatch. This is normal behavior.
+    
+   
+   ![after-rosbag-play](images/rosbag-replay/after-rosbag-play.png)
 
 3. To focus the view on the ego vehicle, change the `Target Frame` in the RViz Views panel from `viewer` to `base_link`.
 

--- a/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
@@ -64,7 +64,7 @@
 
 !!! warning
 
-   You might encounter error and warning messages in the terminal before playing the `rosbag`. This is normal behavior. These should cease once the `rosbag` is played and proper initialization takes place
+You might encounter error and warning messages in the terminal before playing the `rosbag`. This is normal behavior. These should cease once the `rosbag` is played and proper initialization takes place
 
 2. Play the sample rosbag file.
 
@@ -75,9 +75,9 @@
 
 !!! warning
 
-   Due to the discrepancy between the timestamp in the `rosbag` and the current system timestamp, Autoware may generate warning messages in the terminal alerting to this mismatch. This is normal behavior.
+Due to the discrepancy between the timestamp in the `rosbag` and the current system timestamp, Autoware may generate warning messages in the terminal alerting to this mismatch. This is normal behavior.
 
-   ![after-rosbag-play](images/rosbag-replay/after-rosbag-play.png)
+![after-rosbag-play](images/rosbag-replay/after-rosbag-play.png)
 
 3. To focus the view on the ego vehicle, change the `Target Frame` in the RViz Views panel from `viewer` to `base_link`.
 

--- a/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
@@ -62,7 +62,9 @@
 
    ![after-autoware-launch](images/rosbag-replay/after-autoware-launch.png)
 
-   > ⚠️ It might happen that you see in the terminal some error and warning messages before playing the rosbag (next step) unit you play the rosbag and proper initialization occurs
+!!! warning
+
+   You might encounter error and warning messages in the terminal before playing the `rosbag`. This is normal behavior. These should cease once the `rosbag` is played and proper initialization takes place
 
 2. Play the sample rosbag file.
 
@@ -71,7 +73,9 @@
    ros2 bag play ~/autoware_map/sample-rosbag/sample.db3 -r 0.2 -s sqlite3
    ```
 
-   > ⚠️ As the timestamp in the rosbag is different than the current timestamp in your system , Autoware will output in to the terminal some warning messages due to this timestamp mismatch 
+!!! warning
+
+   Due to the discrepancy between the timestamp in the `rosbag` and the current system timestamp, Autoware may generate warning messages in the terminal alerting to this mismatch. This is normal behavior.
 
    ![after-rosbag-play](images/rosbag-replay/after-rosbag-play.png)
 

--- a/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
@@ -62,9 +62,7 @@
 
     ![after-autoware-launch](images/rosbag-replay/after-autoware-launch.png)
 
-    !!! warning
-
-        You might encounter error and warning messages in the terminal before playing the `rosbag`. This is normal behavior. These should cease once the `rosbag` is played and proper initialization takes place
+    > ⚠️ You might encounter error and warning messages in the terminal before playing the `rosbag`. This is normal behavior. These should cease once the `rosbag` is played and proper initialization takes place
 
 2.  Play the sample rosbag file.
 
@@ -73,9 +71,7 @@
     ros2 bag play ~/autoware_map/sample-rosbag/sample.db3 -r 0.2 -s sqlite3
     ```
 
-    !!! warning
-
-        Due to the discrepancy between the timestamp in the `rosbag` and the current system timestamp, Autoware may generate warning messages in the terminal alerting to this mismatch. This is normal behavior.
+    > ⚠️ Due to the discrepancy between the timestamp in the `rosbag` and the current system timestamp, Autoware may generate warning messages in the terminal alerting to this mismatch. This is normal behavior.
 
     ![after-rosbag-play](images/rosbag-replay/after-rosbag-play.png)
 

--- a/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
@@ -64,7 +64,7 @@
 
    !!! warning
 
-    You might encounter error and warning messages in the terminal before playing the `rosbag`. This is normal behavior. These should cease once the `rosbag` is played and proper initialization takes place
+   You might encounter error and warning messages in the terminal before playing the `rosbag`. This is normal behavior. These should cease once the `rosbag` is played and proper initialization takes place
 
 2. Play the sample rosbag file.
 
@@ -75,9 +75,8 @@
 
    !!! warning
 
-    Due to the discrepancy between the timestamp in the `rosbag` and the current system timestamp, Autoware may generate warning messages in the terminal alerting to this mismatch. This is normal behavior.
-    
-   
+   Due to the discrepancy between the timestamp in the `rosbag` and the current system timestamp, Autoware may generate warning messages in the terminal alerting to this mismatch. This is normal behavior.
+
    ![after-rosbag-play](images/rosbag-replay/after-rosbag-play.png)
 
 3. To focus the view on the ego vehicle, change the `Target Frame` in the RViz Views panel from `viewer` to `base_link`.

--- a/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
@@ -51,41 +51,41 @@
 
     If you prefer a graphical user interface (GUI) over the command line for launching and managing your simulations, refer to the `Using Autoware Launch GUI` section at the end of this document for a step-by-step guide.
 
-1. Launch Autoware.
+1.  Launch Autoware.
 
-   ```sh
-   source ~/autoware/install/setup.bash
-   ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
-   ```
+    ```sh
+    source ~/autoware/install/setup.bash
+    ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+    ```
 
-   Note that you cannot use `~` instead of `$HOME` here.
+    Note that you cannot use `~` instead of `$HOME` here.
 
-   ![after-autoware-launch](images/rosbag-replay/after-autoware-launch.png)
+    ![after-autoware-launch](images/rosbag-replay/after-autoware-launch.png)
 
-   !!! warning
+    !!! warning
 
-   You might encounter error and warning messages in the terminal before playing the `rosbag`. This is normal behavior. These should cease once the `rosbag` is played and proper initialization takes place
+        You might encounter error and warning messages in the terminal before playing the `rosbag`. This is normal behavior. These should cease once the `rosbag` is played and proper initialization takes place
 
-2. Play the sample rosbag file.
+2.  Play the sample rosbag file.
 
-   ```sh
-   source ~/autoware/install/setup.bash
-   ros2 bag play ~/autoware_map/sample-rosbag/sample.db3 -r 0.2 -s sqlite3
-   ```
+    ```sh
+    source ~/autoware/install/setup.bash
+    ros2 bag play ~/autoware_map/sample-rosbag/sample.db3 -r 0.2 -s sqlite3
+    ```
 
-   !!! warning
+    !!! warning
 
-   Due to the discrepancy between the timestamp in the `rosbag` and the current system timestamp, Autoware may generate warning messages in the terminal alerting to this mismatch. This is normal behavior.
+        Due to the discrepancy between the timestamp in the `rosbag` and the current system timestamp, Autoware may generate warning messages in the terminal alerting to this mismatch. This is normal behavior.
 
-   ![after-rosbag-play](images/rosbag-replay/after-rosbag-play.png)
+    ![after-rosbag-play](images/rosbag-replay/after-rosbag-play.png)
 
-3. To focus the view on the ego vehicle, change the `Target Frame` in the RViz Views panel from `viewer` to `base_link`.
+3.  To focus the view on the ego vehicle, change the `Target Frame` in the RViz Views panel from `viewer` to `base_link`.
 
-   ![change-target-frame](images/rosbag-replay/change-target-frame.png)
+    ![change-target-frame](images/rosbag-replay/change-target-frame.png)
 
-4. To switch the view to `Third Person Follower` etc, change the `Type` in the RViz Views panel.
+4.  To switch the view to `Third Person Follower` etc, change the `Type` in the RViz Views panel.
 
-   ![third-person-follower](images/rosbag-replay/third-person-follower.png)
+    ![third-person-follower](images/rosbag-replay/third-person-follower.png)
 
 [Reference video tutorials](https://drive.google.com/file/d/12D6aSC1Y3Kf7STtEPWG5RYynxKdVcPrc/view?usp=sharing)
 


### PR DESCRIPTION
## Description

This PR is one of group of PRs that aim to fix Autoware logging system to achieve the goal of reducing excessive error and warning logs on Autoware launch. 

Part of:
- https://github.com/autowarefoundation/autoware.universe/issues/5539


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
