### PR TITLE
fix(data-types/point-cloud): fix document of return_type

### DIFF
--- a/docs/design/autoware-architecture/sensing/data-types/point-cloud.md
+++ b/docs/design/autoware-architecture/sensing/data-types/point-cloud.md
@@ -161,6 +161,10 @@ In the `PointXYZIRCT` and `PointXYZIRC` types, `R` field represents return mode 
 | `1`             | Strongest            |
 | `2`             | Last                 |
 
+!!! note
+
+    The `PointXYZIRC` includes a padding field named `padding`, which is of size `UINT8` and serves for memory alignment purposes for `return_type`.
+
 ### Channel
 
 The channel field is used to identify the vertical channel of the laser that measured the point.


### PR DESCRIPTION
## Description

This PR is for adding a note to `return_type`.
Because of [this PR](https://github.com/autowarefoundation/autoware.universe/pull/6870), `padding` will be added in `PointXYZIRC` (possibly change).

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
