### PR TITLE
feat: update the naming rules for directories and classes

### DIFF
--- a/docs/contributing/coding-guidelines/ros-nodes/class-design.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/class-design.md
@@ -1,5 +1,64 @@
 # Class design
 
+We'll use the `autoware_gnss_poser` package as an example.
+
+## Namespaces
+
+```cpp
+namespace autoware::gnss_poser
+{
+...
+} // namespace autoware::gnss_poser
+```
+
+- Everything should be under `autoware::gnss_poser` namespace.
+- Closing braces should contain a comment with the namespace name.
+
+## Classes
+
+### Nodes
+
+#### `gnss_poser.hpp`
+
+```cpp
+class GNSSPoserNode : public rclcpp::Node
+{
+  public:
+    explicit GNSSPoserNode(const rclcpp::NodeOptions & node_options);
+  ...
+}
+```
+
+#### `gnss_poser.cpp`
+
+```cpp
+GNSSPoserNode::GNSSPoserNode(const rclcpp::NodeOptions & node_options)
+: Node("gnss_poser_node", node_options)
+{
+  ...
+}
+```
+
+- The class name should be in `CamelCase`.
+- Node classes should inherit from `rclcpp::Node`.
+- The constructor should be explicit.
+- The constructor should take `rclcpp::NodeOptions` as an argument.
+- Default node name should be `gnss_poser_node`.
+
+##### Component registration
+
+```cpp
+...
+} // namespace autoware::gnss_poser
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::gnss_poser::GNSSPoserNode)
+```
+
+- The component should be registered at the end of the `autoware_gnss_poser.cpp` file, outside the namespaces.
+
+### Libraries
+
 !!! warning
 
     Under Construction

--- a/docs/contributing/coding-guidelines/ros-nodes/class-design.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/class-design.md
@@ -33,7 +33,7 @@ class GNSSPoserNode : public rclcpp::Node
 
 ```cpp
 GNSSPoserNode::GNSSPoserNode(const rclcpp::NodeOptions & node_options)
-: Node("gnss_poser_node", node_options)
+: Node("gnss_poser", node_options)
 {
   ...
 }
@@ -45,8 +45,9 @@ GNSSPoserNode::GNSSPoserNode(const rclcpp::NodeOptions & node_options)
 - The constructor should take `rclcpp::NodeOptions` as an argument.
 - Default node name:
   - should not have `autoware_` prefix.
-  - should have `_node` suffix.
-  - **Example:** `gnss_poser_node`.
+  - should **NOT** have `_node` suffix.
+    - **Rationale:** Node names are useful in the runtime. And output of `ros2 node list` will show only nodes anyway. Having `_node` is redundant.
+  - **Example:** `gnss_poser`.
 
 ##### Component registration
 

--- a/docs/contributing/coding-guidelines/ros-nodes/class-design.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/class-design.md
@@ -43,7 +43,10 @@ GNSSPoserNode::GNSSPoserNode(const rclcpp::NodeOptions & node_options)
 - Node classes should inherit from `rclcpp::Node`.
 - The constructor should be explicit.
 - The constructor should take `rclcpp::NodeOptions` as an argument.
-- Default node name should be `gnss_poser_node`.
+- Default node name:
+  - should not have `autoware_` prefix.
+  - should have `_node` suffix.
+  - **Example:** `gnss_poser_node`.
 
 ##### Component registration
 

--- a/docs/contributing/coding-guidelines/ros-nodes/class-design.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/class-design.md
@@ -12,7 +12,7 @@ namespace autoware::gnss_poser
 ```
 
 - Everything should be under `autoware::gnss_poser` namespace.
-- Closing braces should contain a comment with the namespace name.
+- Closing braces must contain a comment with the namespace name. (Automated with `cpplint`)
 
 ## Classes
 
@@ -41,8 +41,8 @@ GNSSPoserNode::GNSSPoserNode(const rclcpp::NodeOptions & node_options)
 
 - The class name should be in `CamelCase`.
 - Node classes should inherit from `rclcpp::Node`.
-- The constructor should be explicit.
-- The constructor should take `rclcpp::NodeOptions` as an argument.
+- The constructor must be marked be explicit.
+- The constructor must take `rclcpp::NodeOptions` as an argument.
 - Default node name:
   - should not have `autoware_` prefix.
   - should **NOT** have `_node` suffix.

--- a/docs/contributing/coding-guidelines/ros-nodes/class-design.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/class-design.md
@@ -18,7 +18,7 @@ namespace autoware::gnss_poser
 
 ### Nodes
 
-#### `gnss_poser.hpp`
+#### `gnss_poser_node.hpp`
 
 ```cpp
 class GNSSPoserNode : public rclcpp::Node
@@ -29,7 +29,7 @@ class GNSSPoserNode : public rclcpp::Node
 }
 ```
 
-#### `gnss_poser.cpp`
+#### `gnss_poser_node.cpp`
 
 ```cpp
 GNSSPoserNode::GNSSPoserNode(const rclcpp::NodeOptions & node_options)
@@ -58,7 +58,7 @@ GNSSPoserNode::GNSSPoserNode(const rclcpp::NodeOptions & node_options)
 RCLCPP_COMPONENTS_REGISTER_NODE(autoware::gnss_poser::GNSSPoserNode)
 ```
 
-- The component should be registered at the end of the `autoware_gnss_poser.cpp` file, outside the namespaces.
+- The component should be registered at the end of the `gnss_poser_node.cpp` file, outside the namespaces.
 
 ### Libraries
 

--- a/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
@@ -82,7 +82,11 @@ The package folder name should be the same as the package name.
 - The [`project()`](https://cmake.org/cmake/help/latest/command/project.html) command should call the package name.
   - **Example:** `project(autoware_gnss_poser)`
 
-##### Exporting a composable node as a standalone node executable
+##### Exporting a composable node component executables
+
+For best practices and system efficiency, it is recommended to primarily use composable node components.
+
+This method facilitates easier deployment and maintenance within ROS environments.
 
 ```cmake
 ament_auto_add_library(${PROJECT_NAME} SHARED
@@ -95,8 +99,34 @@ rclcpp_components_register_node(${PROJECT_NAME}
 )
 ```
 
-- The composable node executable should have `_node` suffix.
-- The composable node executable should start with `${PROJECT_NAME}`
+- If you are building:
+  - **only a single composable node component,** the executable name should start with `${PROJECT_NAME}`
+  - **multiple composable node components,** the executable name is up to the developer.
+- All composable node component executables should have the `_node` suffix.
+
+##### Exporting a standalone node executable without composition _(discouraged for most cases)_
+
+Use of standalone executables **should be limited** to cases where specific needs such as debugging or tooling are required.
+
+[Exporting a composable node component executables](#exporting-a-composable-node-component-executables) is generally preferred for standard operational use due its flexibility and scalability within the ROS ecosystem.
+
+Assuming:
+
+- `src/gnss_poser.cpp` has the `GNSSPoserNode` class.
+- `src/gnss_poser_node.cpp` has the `main` function.
+- There is no composable node component registration.
+
+```cmake
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/gnss_poser.cpp
+)
+
+ament_auto_add_executable(${PROJECT_NAME}_node src/gnss_poser_node.cpp)
+```
+
+- The node executable:
+  - should have `_node` suffix.
+  - should start with `${PROJECT_NAME}
 
 ### `config` and `schema`
 

--- a/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
@@ -153,7 +153,7 @@ autoware_gnss_poser
 - The source file exporting the node should:
   - have `_node` suffix.
     - **Rationale:** To distinguish from other source files.
-  - **NOT** have `_autoware` prefix.
+  - **NOT** have `autoware_` prefix.
     - **Rationale:** To avoid verbosity.
 - See [Classes](../../class-design.md) for more details on how to construct `gnss_poser_node.hpp` and `gnss_poser_node.cpp` files.
 

--- a/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
@@ -1,75 +1,168 @@
 # Directory structure
 
-!!! warning
+This document describes the directory structure of ROS nodes within Autoware.
 
-    Under Construction
+We'll use the package `autoware_gnss_poser` as an example.
 
 ## C++ package
 
+### Package name
+
+- All the packages in Autoware should be prefixed with `autoware_`.
+- Even if the package is exports a node, the package name **should NOT** have the `_node` suffix.
+- The package name should be in `snake_case`.
+
+| Package Name                      | OK | Alternative                  |
+|-----------------------------------|----|------------------------------|
+| path_smoother                     | ❌  | autoware_path_smoother       |
+| autoware_trajectory_follower_node | ❌  | autoware_trajectory_follower |
+| autoware_geography_utils          | ✅  | -                            |
+
+### Package folder
+
 ```txt
-<package_name>
-├─ config
-│   ├─ foo_ros.param.yaml
-│   └─ foo_non_ros.yaml
-├─ doc
-│   ├─ foo_document.md
-│   └─ foo_diagram.svg
-├─ include
-│   └─ <package_name>
-│       └─ foo_public.hpp
-├─ launch
-│   ├─ foo.launch.xml
-│   └─ foo.launch.py
-├─ schema
-│   └─ foo_node.schema.json
-├─ src
-│   ├─ foo_node.cpp
-│   ├─ foo_node.hpp
-│   └─ foo_private.hpp
-├─ test
-│   └─ test_foo.cpp
+autoware_gnss_poser
 ├─ package.xml
 ├─ CMakeLists.txt
 └─ README.md
 ```
 
-### Directory descriptions
+The package folder name should be the same as the package name.
+
+#### `package.xml`
+
+- The package name should be entered within the `<name>` tag.
+   - `<name>autoware_gnss_poser</name>`
+
+#### `CMakeLists.txt`
+
+- The [`project()`](https://cmake.org/cmake/help/latest/command/project.html) command should call the package name.
+   - **Example:** `project(autoware_gnss_poser)`
+
+##### Exporting a component
+
+```cmake
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/gnss_poser_node.cpp
+)
+
+rclcpp_components_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::gnss_poser::GNSSPoserNode"
+  EXECUTABLE ${PROJECT_NAME}_node
+)
+```
+
+- The component executable should have `_node` suffix.
+- The component executable name should start with `${PROJECT_NAME}`
+
+### `config` and `schema`
+
+```txt
+autoware_gnss_poser
+│─ config
+│   ├─ gnss_poser.param.yaml
+│   └─ another_non_ros_config.yaml
+└─ schema
+    └─ gnss_poser.schema.json
+```
 
 #### `config`
 
-Place configuration files such as node parameters.
-For ROS parameters, use the extension `.param.yaml`.
-For non-ROS parameters, use the extension `.yaml`.
+- ROS parameters uses the extension `.param.yaml`.
+- Non-ROS parameters use the extension `.yaml`.
 
-Rationale: Since ROS parameters files are type-sensitive, they should not be the target of some code formatters and linters. In order to distinguish the file type, we use different file extensions.
-
-#### `doc`
-
-Place document files and link from README.
-
-#### `include`
-
-Place header files exposed to other packages. Do not place files directly under the `include` directory, but place files under the directory with the package name.
-This directory is used for mostly library headers. Note that many headers do not need to be placed here. It is enough to place the headers under the `src` directory.
-
-Reference: <https://docs.ros.org/en/humble/How-To-Guides/Ament-CMake-Documentation.html#adding-targets>
-
-#### `launch`
-
-Place launch files (`.launch.xml` and `.launch.py`).
+Rationale: Different linting rules are used for ROS parameters and non-ROS parameters.
 
 #### `schema`
 
-Place parameter definition files. See [parameters](./parameters.md) for details.
+Place parameter definition files. See [Parameters](./parameters.md) for details.
 
-#### `src`
+### `doc`
 
-Place source files and private header files.
+```txt
+autoware_gnss_poser
+└─ doc
+    ├─ foo_document.md
+    └─ foo_diagram.svg
+```
 
-#### `test`
+Place documentation files and link them from the README file.
+
+### `include` and `src`
+
+- Unless you specifically need to export headers, you shouldn't have a `include` directory under the package directory.
+- For most cases, follow [Not exporting headers](#not-exporting-headers).
+- Library packages that export headers may follow [Exporting headers](#exporting-headers).
+
+#### Not exporting headers
+
+```txt
+autoware_gnss_poser
+└─ src
+    ├─ include
+    │   ├─ gnss_poser_node.hpp
+    │   └─ foo.hpp
+    │─ gnss_poser_node.cpp
+    └─ bar.cpp
+```
+
+- Put the header files in the `include` directory under the `src` directory.
+- The source file exporting the node should:
+   - have `_node` suffix.
+      - **Rationale:** To distinguish from other source files.
+   - **NOT** have `_autoware` prefix.
+      - **Rationale:** To avoid verbosity.
+- See [Classes](../../class-design.md) for more details on how to construct `gnss_poser_node.hpp` and `gnss_poser_node.cpp` files.
+
+#### Exporting headers
+
+```txt
+autoware_gnss_poser
+└─ include
+    └─ autoware
+        └─ gnss_poser
+            └─ exported_header.hpp
+```
+
+- `autoware_gnss_poser/include` folder should contain **ONLY** the `autoware` folder.
+   - **Rationale:** When installing ROS debian packages, the headers are copied to the `/opt/ros/humble/include/` directory. This structure is used to avoid conflicts with non-Autoware packages.
+- `autoware_gnss_poser/include/autoware` folder should contain **ONLY** the `gnss_poser` folder.
+   - **Rationale:** Similarly, this structure is used to avoid conflicts with other packages.
+- `autoware_gnss_poser/include/autoware/gnss_poser` folder should contain the header files to be exported.
+
+**Note:** If `ament_auto_package()` command is used in the `CMakeLists.txt` file and `autoware_gnss_poser/include` folder exists,
+this `include` folder will be exported to the `install` folder as part of [ament_auto_package.cmake](https://github.com/ament/ament_cmake/blob/79cc237f8eb819edf4c1c624b56451e0a05a45f8/ament_cmake_auto/cmake/ament_auto_package.cmake#L62-L66)
+
+**Reference:** <https://docs.ros.org/en/humble/How-To-Guides/Ament-CMake-Documentation.html#adding-targets>
+
+### `launch`
+
+```txt
+autoware_gnss_poser
+└─ launch
+    ├─ gnss_poser.launch.xml
+    └─ gnss_poser.launch.py
+```
+
+- You may have multiple launch files here.
+- Unless you have a specific reason, use the `.launch.xml` extension.
+   - **Rationale:** While the `.launch.py` extension is more flexible, it comes with a readability cost.
+- Avoid `autoware_` prefix in the launch file names.
+   - **Rationale:** To avoid verbosity.
+
+### `test`
+
+```txt
+autoware_gnss_poser
+└─ test
+    ├─ test_foo.hpp # or place under an `include` folder here
+    └─ test_foo.cpp
+```
 
 Place source files for testing. See [unit testing](../../testing-guidelines/unit-testing.md) for details.
 
 ## Python package
 
-T.B.D.
+!!! warning
+
+    Under Construction

--- a/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
@@ -102,6 +102,7 @@ rclcpp_components_register_node(${PROJECT_NAME}
 ##### Exporting a standalone node executable
 
 Assuming:
+
 - `src/gnss_poser.cpp` has the `GNSSPoserNode` class.
 - `src/gnss_poser_node.cpp` has the `main` function.
 - There is no composable node component registration.

--- a/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
@@ -12,8 +12,8 @@ We'll use the package `autoware_gnss_poser` as an example.
 - Even if the package is exports a node, the package name **should NOT** have the `_node` suffix.
 - The package name should be in `snake_case`.
 
-| Package Name                      | OK | Alternative                  |
-|-----------------------------------|----|------------------------------|
+| Package Name                      | OK  | Alternative                  |
+| --------------------------------- | --- | ---------------------------- |
 | path_smoother                     | ❌  | autoware_path_smoother       |
 | autoware_trajectory_follower_node | ❌  | autoware_trajectory_follower |
 | autoware_geography_utils          | ✅  | -                            |
@@ -32,12 +32,12 @@ The package folder name should be the same as the package name.
 #### `package.xml`
 
 - The package name should be entered within the `<name>` tag.
-   - `<name>autoware_gnss_poser</name>`
+  - `<name>autoware_gnss_poser</name>`
 
 #### `CMakeLists.txt`
 
 - The [`project()`](https://cmake.org/cmake/help/latest/command/project.html) command should call the package name.
-   - **Example:** `project(autoware_gnss_poser)`
+  - **Example:** `project(autoware_gnss_poser)`
 
 ##### Exporting a component
 
@@ -108,10 +108,10 @@ autoware_gnss_poser
 
 - Put the header files in the `include` directory under the `src` directory.
 - The source file exporting the node should:
-   - have `_node` suffix.
-      - **Rationale:** To distinguish from other source files.
-   - **NOT** have `_autoware` prefix.
-      - **Rationale:** To avoid verbosity.
+  - have `_node` suffix.
+    - **Rationale:** To distinguish from other source files.
+  - **NOT** have `_autoware` prefix.
+    - **Rationale:** To avoid verbosity.
 - See [Classes](../../class-design.md) for more details on how to construct `gnss_poser_node.hpp` and `gnss_poser_node.cpp` files.
 
 #### Exporting headers
@@ -125,9 +125,9 @@ autoware_gnss_poser
 ```
 
 - `autoware_gnss_poser/include` folder should contain **ONLY** the `autoware` folder.
-   - **Rationale:** When installing ROS debian packages, the headers are copied to the `/opt/ros/humble/include/` directory. This structure is used to avoid conflicts with non-Autoware packages.
+  - **Rationale:** When installing ROS debian packages, the headers are copied to the `/opt/ros/humble/include/` directory. This structure is used to avoid conflicts with non-Autoware packages.
 - `autoware_gnss_poser/include/autoware` folder should contain **ONLY** the `gnss_poser` folder.
-   - **Rationale:** Similarly, this structure is used to avoid conflicts with other packages.
+  - **Rationale:** Similarly, this structure is used to avoid conflicts with other packages.
 - `autoware_gnss_poser/include/autoware/gnss_poser` folder should contain the header files to be exported.
 
 **Note:** If `ament_auto_package()` command is used in the `CMakeLists.txt` file and `autoware_gnss_poser/include` folder exists,
@@ -146,9 +146,9 @@ autoware_gnss_poser
 
 - You may have multiple launch files here.
 - Unless you have a specific reason, use the `.launch.xml` extension.
-   - **Rationale:** While the `.launch.py` extension is more flexible, it comes with a readability cost.
+  - **Rationale:** While the `.launch.py` extension is more flexible, it comes with a readability cost.
 - Avoid `autoware_` prefix in the launch file names.
-   - **Rationale:** To avoid verbosity.
+  - **Rationale:** To avoid verbosity.
 
 ### `test`
 

--- a/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
@@ -82,7 +82,7 @@ The package folder name should be the same as the package name.
 - The [`project()`](https://cmake.org/cmake/help/latest/command/project.html) command should call the package name.
   - **Example:** `project(autoware_gnss_poser)`
 
-##### Exporting a composable node component executable
+##### Exporting a composable node as a standalone node executable
 
 ```cmake
 ament_auto_add_library(${PROJECT_NAME} SHARED
@@ -95,29 +95,8 @@ rclcpp_components_register_node(${PROJECT_NAME}
 )
 ```
 
-- The composable node component executable:
-  - should have `_node` suffix.
-  - should start with `${PROJECT_NAME}`
-
-##### Exporting a standalone node executable
-
-Assuming:
-
-- `src/gnss_poser.cpp` has the `GNSSPoserNode` class.
-- `src/gnss_poser_node.cpp` has the `main` function.
-- There is no composable node component registration.
-
-```cmake
-ament_auto_add_library(${PROJECT_NAME} SHARED
-  src/gnss_poser.cpp
-)
-
-ament_auto_add_executable(${PROJECT_NAME}_node src/gnss_poser_node.cpp)
-```
-
-- The node executable:
-  - should have `_node` suffix.
-  - should start with `${PROJECT_NAME}`
+- The composable node executable should have `_node` suffix.
+- The composable node executable should start with `${PROJECT_NAME}`
 
 ### `config` and `schema`
 

--- a/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
@@ -6,6 +6,49 @@ We'll use the package `autoware_gnss_poser` as an example.
 
 ## C++ package
 
+### Entire structure
+
+- This is a reference on how the entire package might be structured.
+- A package may not have all the directories shown here.
+
+```txt
+autoware_gnss_poser
+├─ package.xml
+├─ CMakeLists.txt
+├─ README.md
+│
+├─ config
+│   ├─ gnss_poser.param.yaml
+│   └─ another_non_ros_config.yaml
+│
+├─ schema
+│   └─ gnss_poser.schema.json
+│
+├─ doc
+│   ├─ foo_document.md
+│   └─ foo_diagram.svg
+│
+├─ include  # for exporting headers
+│   └─ autoware
+│       └─ gnss_poser
+│           └─ exported_header.hpp
+│
+├─ src
+│   ├─ include
+│   │   ├─ gnss_poser_node.hpp
+│   │   └─ foo.hpp
+│   ├─ gnss_poser_node.cpp
+│   └─ bar.cpp
+│
+├─ launch
+│   ├─ gnss_poser.launch.xml
+│   └─ gnss_poser.launch.py
+│
+└─ test
+    ├─ test_foo.hpp  # or place under an `include` folder here
+    └─ test_foo.cpp
+```
+
 ### Package name
 
 - All the packages in Autoware should be prefixed with `autoware_`.
@@ -71,7 +114,7 @@ autoware_gnss_poser
 - ROS parameters uses the extension `.param.yaml`.
 - Non-ROS parameters use the extension `.yaml`.
 
-Rationale: Different linting rules are used for ROS parameters and non-ROS parameters.
+**Rationale:** Different linting rules are used for ROS parameters and non-ROS parameters.
 
 #### `schema`
 
@@ -125,7 +168,7 @@ autoware_gnss_poser
 ```
 
 - `autoware_gnss_poser/include` folder should contain **ONLY** the `autoware` folder.
-  - **Rationale:** When installing ROS debian packages, the headers are copied to the `/opt/ros/humble/include/` directory. This structure is used to avoid conflicts with non-Autoware packages.
+  - **Rationale:** When installing ROS debian packages, the headers are copied to the `/opt/ros/$ROS_DISTRO/include/` directory. This structure is used to avoid conflicts with non-Autoware packages.
 - `autoware_gnss_poser/include/autoware` folder should contain **ONLY** the `gnss_poser` folder.
   - **Rationale:** Similarly, this structure is used to avoid conflicts with other packages.
 - `autoware_gnss_poser/include/autoware/gnss_poser` folder should contain the header files to be exported.
@@ -155,7 +198,7 @@ autoware_gnss_poser
 ```txt
 autoware_gnss_poser
 └─ test
-    ├─ test_foo.hpp # or place under an `include` folder here
+    ├─ test_foo.hpp  # or place under an `include` folder here
     └─ test_foo.cpp
 ```
 

--- a/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
@@ -82,7 +82,7 @@ The package folder name should be the same as the package name.
 - The [`project()`](https://cmake.org/cmake/help/latest/command/project.html) command should call the package name.
   - **Example:** `project(autoware_gnss_poser)`
 
-##### Exporting a component
+##### Exporting a composable node component executable
 
 ```cmake
 ament_auto_add_library(${PROJECT_NAME} SHARED
@@ -95,8 +95,28 @@ rclcpp_components_register_node(${PROJECT_NAME}
 )
 ```
 
-- The component executable should have `_node` suffix.
-- The component executable name should start with `${PROJECT_NAME}`
+- The composable node component executable:
+  - should have `_node` suffix.
+  - should start with `${PROJECT_NAME}`
+
+##### Exporting a standalone node executable
+
+Assuming:
+- `src/gnss_poser.cpp` has the `GNSSPoserNode` class.
+- `src/gnss_poser_node.cpp` has the `main` function.
+- There is no composable node component registration.
+
+```cmake
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/gnss_poser.cpp
+)
+
+ament_auto_add_executable(${PROJECT_NAME}_node src/gnss_poser_node.cpp)
+```
+
+- The node executable:
+  - should have `_node` suffix.
+  - should start with `${PROJECT_NAME}`
 
 ### `config` and `schema`
 

--- a/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
@@ -147,15 +147,25 @@ autoware_gnss_poser
     │   └─ foo.hpp
     │─ gnss_poser_node.cpp
     └─ bar.cpp
+
+OR
+
+autoware_gnss_poser
+└─ src
+    ├─ gnss_poser_node.hpp
+    ├─ gnss_poser_node.cpp
+    ├─ foo.hpp
+    └─ bar.cpp
 ```
 
-- Put the header files in the `include` directory under the `src` directory.
 - The source file exporting the node should:
   - have `_node` suffix.
     - **Rationale:** To distinguish from other source files.
   - **NOT** have `autoware_` prefix.
     - **Rationale:** To avoid verbosity.
 - See [Classes](../../class-design.md) for more details on how to construct `gnss_poser_node.hpp` and `gnss_poser_node.cpp` files.
+- It is up to developer how to organize the source files under `src`.
+  - **Note:** The `include` folder under `src` is optional.
 
 #### Exporting headers
 

--- a/docs/contributing/coding-guidelines/ros-nodes/parameters.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/parameters.md
@@ -11,7 +11,7 @@ Find more information on parameters from the official ROS documentation:
 
 A ROS package which uses the [declare_parameter(...)](https://docs.ros.org/en/ros2_packages/humble/api/rclcpp/generated/classrclcpp_1_1Node.html#_CPPv4N6rclcpp4Node17declare_parameterERKNSt6stringERKN6rclcpp14ParameterValueERKN14rcl_interfaces3msg19ParameterDescriptorEb) function should:
 
-- use the [declare_parameter(...)](https://docs.ros.org/en/ros2_packages/humble/api/rclcpp/generated/classrclcpp_1_1Node.html#_CPPv4N6rclcpp4Node17declare_parameterERKNSt6stringERKN6rclcpp14ParameterValueERKN14rcl_interfaces3msg19ParameterDescriptorEb) with out a default value
+- use the [declare_parameter(...)](https://docs.ros.org/en/ros2_packages/humble/api/rclcpp/generated/classrclcpp_1_1Node.html#_CPPv4N6rclcpp4Node17declare_parameterERKNSt6stringERKN6rclcpp14ParameterValueERKN14rcl_interfaces3msg19ParameterDescriptorEb) without a default value
 - create a parameter file
 - create a schema file
 


### PR DESCRIPTION
## Description

Previous discussions:
- https://github.com/autowarefoundation/autoware/issues/4569
- https://github.com/orgs/autowarefoundation/discussions/4097

As we are prefixing the packages with `autoware_`, we needed to clear the rules to avoid confusion.

Using or omitting the `autoware_` prefix or `_node` suffix can be highly confusing without clear guidelines.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
