### PR TITLE
fix: to improve the readability of the documentation, unified the name of the sensor_kit repository to YOUR_SENSOR_KIT_launch

### DIFF
--- a/docs/how-to-guides/integrating-autoware/overview.md
+++ b/docs/how-to-guides/integrating-autoware/overview.md
@@ -69,7 +69,7 @@ Define URDF and parameters in the vehicle description package (refer to the [sam
 Create a launch file (refer to the [sample vehicle launch package](https://github.com/autowarefoundation/sample_vehicle_launch/tree/main/sample_vehicle_launch) for example).
 If you have multiple vehicles with the same hardware setup, you can specify `vehicle_id` to distinguish them.
 
-### Adapt YOUR_SENSOR_KIT_description for autoware launching system
+### Adapt YOUR_SENSOR_KIT_launch for autoware launching system
 
 #### At YOUR_SENSOR_KIT_description
 


### PR DESCRIPTION
## Description

According to autoware.repos, the structure is as follows:

YOUR_SENSOR_KIT_**launch**/
├── YOUR_SENSOR_KIT_description/
└── YOUR_SENSOR_KIT_launch/

![image](https://github.com/autowarefoundation/autoware-documentation/assets/42679530/386d30f3-ca04-4ea5-821b-6b3e5d3f60ad)



Made changes because the documentation described the structure as follows before the changes:

YOUR_SENSOR_KIT_**description**/
├── YOUR_SENSOR_KIT_description/
└── YOUR_SENSOR_KIT_launch/

![image](https://github.com/autowarefoundation/autoware-documentation/assets/42679530/f7665af7-962e-4d17-836a-05bef867420b)



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
