### PR TITLE
 docs: add the PanoSim simulator page under digital twin

### DIFF
--- a/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/panosim-tutorial.md
+++ b/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/panosim-tutorial.md
@@ -1,21 +1,18 @@
 # PanoSim simulator
 
 ## Overview
+
 PanoSim is an integrated testing simulation platform for anoautonomous driving, and its technologies and product development.
 
 [PanoSim and Autoware co-simulation tutorial](https://gitee.com/wobuzhuchele/panosim-autoware/blob/master/README.en.md). Based on PanoSim V32 and Autoware.universe, it includes bridge, map ,scenarios, installation tutorial.
 
-
-##  Instructions
+## Instructions
 
 1.  [PanoSim-Autoware Framework](https://gitee.com/wobuzhuchele/panosim-autoware/blob/master/Document/PanoSim-Autoware.en.md)
 2.  [Co-simulation PanoSim Configuration Tutorial](https://gitee.com/wobuzhuchele/panosim-autoware/blob/master/Document/PanoSim-Autoware%20PanoSim.en.md), [ROS2 Configuration Tutorial](https://gitee.com/wobuzhuchele/panosim-autoware/blob/master/Document/ROS2%20Bridge.en.md)
 3.  [Co-simulation AutoWare Configuration Tutorial](https://gitee.com/wobuzhuchele/panosim-autoware/blob/master/Document/PanoSim-Autoware%20Autoware.en.md)
-   
 
 ## Development
 
 Currently ,development is still ongoing,with many feature updates planned.
 If you encounter any issues or have suggestions, please submit them as [Issues](https://gitee.com/wobuzhuchele/panosim-autoware/issues).
-
-

--- a/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/panosim-tutorial.md
+++ b/docs/tutorials/ad-hoc-simulation/digital-twin-simulation/panosim-tutorial.md
@@ -1,0 +1,21 @@
+# PanoSim simulator
+
+## Overview
+PanoSim is an integrated testing simulation platform for anoautonomous driving, and its technologies and product development.
+
+[PanoSim and Autoware co-simulation tutorial](https://gitee.com/wobuzhuchele/panosim-autoware/blob/master/README.en.md). Based on PanoSim V32 and Autoware.universe, it includes bridge, map ,scenarios, installation tutorial.
+
+
+##  Instructions
+
+1.  [PanoSim-Autoware Framework](https://gitee.com/wobuzhuchele/panosim-autoware/blob/master/Document/PanoSim-Autoware.en.md)
+2.  [Co-simulation PanoSim Configuration Tutorial](https://gitee.com/wobuzhuchele/panosim-autoware/blob/master/Document/PanoSim-Autoware%20PanoSim.en.md), [ROS2 Configuration Tutorial](https://gitee.com/wobuzhuchele/panosim-autoware/blob/master/Document/ROS2%20Bridge.en.md)
+3.  [Co-simulation AutoWare Configuration Tutorial](https://gitee.com/wobuzhuchele/panosim-autoware/blob/master/Document/PanoSim-Autoware%20Autoware.en.md)
+   
+
+## Development
+
+Currently ,development is still ongoing,with many feature updates planned.
+If you encounter any issues or have suggestions, please submit them as [Issues](https://gitee.com/wobuzhuchele/panosim-autoware/issues).
+
+


### PR DESCRIPTION
Add the PanoSim simulator page. Based on PanoSim V32 and Autoware.universe, it includes bridge, map ,scenarios, installation tutorial.

## Description

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
