### PR TITLE
feat(support-guidelines): update guidelines for Autoware community support

### DIFF
--- a/docs/support/support-guidelines.md
+++ b/docs/support/support-guidelines.md
@@ -85,7 +85,7 @@ If you find out that some information is wrong, unclear, or missing in Autoware 
 
 !!! warning
 
-    Github Discussions is not the right place to track tasks or bugs. Use GitHub Issues for that purpose.
+    GitHub Discussions is not the right place to track tasks or bugs. Use GitHub Issues for that purpose.
 
 ## GitHub Issues
 

--- a/docs/support/support-guidelines.md
+++ b/docs/support/support-guidelines.md
@@ -10,18 +10,52 @@ This page explains the support mechanisms we provide.
 Choose appropriate resources depending on what kind of help you need and read the detailed description in the sections below.
 
 - [Documentation sites](#documentation-sites)
-  - Various information
+  - Gathering information
 - [GitHub Discussions](#github-discussions)
-  - Questions
-  - Unconfirmed bugs
-  - Feature requests
-  - Design discussions
+  - Questions or unconfirmed bugs -> [Q&A](https://github.com/orgs/autowarefoundation/discussions/categories/q-a)
+  - [Feature requests](https://github.com/orgs/autowarefoundation/discussions/categories/feature-requests)
+  - [Design discussions](https://github.com/orgs/autowarefoundation/discussions/categories/design)
 - [GitHub Issues](#github-issues)
   - Confirmed bugs
+  - Confirmed tasks
 - [Discord](#discord)
   - Instant messaging between contributors
 - [ROS Discourse](#ros-discourse)
   - General topics that should be widely announced
+
+## Guidelines for Autoware community support
+
+If you encounter a problem with Autoware, please follow these steps to seek help:
+
+### 1. Search for existing Issues and Questions
+
+Before creating a new issue or question, check if someone else has already reported or asked about the problem. Use the following resources:
+
+- **[Issues](https://github.com/autowarefoundation/autoware/issues)**
+
+  Note that Autoware has multiple repositories listed in [autoware.repos](https://github.com/autowarefoundation/autoware/blob/main/autoware.repos). 
+  It is recommended to search across all repositories.
+
+- **[Questions](https://github.com/autowarefoundation/autoware/discussions/categories/q-a)**
+
+### 2. Create a new question thread
+
+If you don't find an existing issue or question that addresses your problem, create a new question thread:
+
+- **[Ask a Question](https://github.com/autowarefoundation/autoware/discussions/categories/q-a)**
+
+  If your question is not answered within a week, mention `@autoware-maintainers` in a post to remind them.
+
+### 3. Participate in other discussions
+
+You are also welcome to open or join discussions in other categories:
+
+- **[Feature requests](https://github.com/autowarefoundation/autoware/discussions/categories/feature-requests)**
+- **[Design discussions](https://github.com/autowarefoundation/autoware/discussions/categories/design)**
+
+### Additional resources
+
+If you are unsure how to create a discussion, refer to the [GitHub Docs on creating a new discussion](https://docs.github.com/en/discussions/quickstart#creating-a-new-discussion).
 
 ## Documentation sites
 
@@ -31,39 +65,65 @@ Visit them and see if there is any information related to your problem.
 Note that the documentation sites aren't always up-to-date and perfect.
 If you find out that some information is wrong, unclear, or missing in Autoware docs, feel free to submit a pull request following the [contribution guidelines](../contributing/index.md).
 
-!!! warning
-
-    Since this documentation site is still under construction, there are some empty pages.
-
 ## GitHub Discussions
 
-If you encounter a problem with Autoware, check existing issues and questions and search for similar issues first.
+[GitHub discussions page](https://github.com/orgs/autowarefoundation/discussions) is the primary place for asking questions and discussing topics related to Autoware.
 
-- [Issues](https://github.com/autowarefoundation/autoware/issues)
+| Category                                                                                                               | Description                                                             |
+|:-----------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------|
+| [Announcements](https://github.com/orgs/autowarefoundation/discussions/categories/announcements)                       | Official updates and news from the Autoware maintainers                 |
+| [Design](https://github.com/orgs/autowarefoundation/discussions/categories/design)                                     | Discussions on Autoware system and software design                      |
+| [Feature requests](https://github.com/orgs/autowarefoundation/discussions/categories/feature-requests)                 | Suggestions for new features and improvements                           |
+| [General](https://github.com/orgs/autowarefoundation/discussions/categories/general)                                   | General discussions about Autoware                                      |
+| [Ideas](https://github.com/orgs/autowarefoundation/discussions/categories/ideas)                                       | Brainstorming and sharing innovative ideas                              |
+| [Polls](https://github.com/orgs/autowarefoundation/discussions/categories/polls)                                       | Community polls and surveys                                             |
+| [Q&A](https://github.com/orgs/autowarefoundation/discussions/categories/q-a)                                           | Questions and answers from the community and developers                 |
+| [Show and tell](https://github.com/orgs/autowarefoundation/discussions/categories/show-and-tell)                       | Showcase of projects and achievements                                   |
+| [TSC meetings](https://github.com/orgs/autowarefoundation/discussions/categories/tsc-meetings)                         | Minutes and discussions from TSC(Technical Steering Committee) meetings |
+| [Working group activities](https://github.com/orgs/autowarefoundation/discussions/categories/working-group-activities) | Updates on working group activities                                     |
+| [Working group meetings](https://github.com/orgs/autowarefoundation/discussions/categories/working-group-meetings)     | Minutes and discussions from working group meetings                     |
 
-  Note that Autoware has multiple repositories listed in [autoware.repos](https://github.com/autowarefoundation/autoware/blob/main/autoware.repos).  
-  It is recommended to search across the repositories.
+!!! warning
 
-- [Questions](https://github.com/autowarefoundation/autoware/discussions/categories/q-a)
-
-If no answer was found, create a new question thread [here](https://github.com/autowarefoundation/autoware/discussions/categories/q-a).
-If your question is not answered within a week, then @mention the maintainers to remind them.
-
-Also, there are other discussion types such as [feature requests](https://github.com/autowarefoundation/autoware/discussions/categories/feature-requests) or [design discussions](https://github.com/autowarefoundation/autoware/discussions/categories/design).
-Feel free to open or join such discussions.
-
-If you don't know how to create a discussion, refer to [GitHub Docs](https://docs.github.com/en/discussions/quickstart#creating-a-new-discussion).
+    Github Discussions is not the right place to track tasks or bugs. Use GitHub Issues for that purpose.
 
 ## GitHub Issues
 
-If you have a problem and you have confirmed it is a bug, find the appropriate repository and create a new issue there.
-If you can't determine the appropriate repository, ask the maintainers for help by creating a new discussion in the [Q&A category](https://github.com/autowarefoundation/autoware/discussions/categories/q-a).
+GitHub Issues is the designated platform for tracking confirmed bugs, tasks, and enhancements within Autoware's various repositories.
+
+Follow these guidelines to ensure efficient issue tracking and resolution:
+
+### Reporting bugs
+
+If you encounter a confirmed bug, please report it by creating an issue in the appropriate Autoware repository.
+Include detailed information such as steps to reproduce, expected outcomes, and actual results to assist maintainers in addressing the issue promptly.
+
+### Tracking tasks
+
+GitHub Issues is also the place for managing tasks including:
+
+- **Refactoring:** Propose refactoring existing code to improve efficiency, readability, or maintainability. Clearly describe what and why you propose to refactor.
+- **New Features:** If you have confirmed the need for a new feature through discussions, use Issues to track its development. Outline the feature's purpose, potential designs, and its intended impact.
+- **Documentation:** Propose changes to documentation to fix inaccuracies, update outdated content, or add new sections. Specify what changes are needed and why they are important.
+
+### Creating an issue
+
+When creating a new issue, use the following guidelines:
+
+1. **Choose the Correct Repository**: If unsure which repository is appropriate, start a discussion in the [Q&A category](https://github.com/autowarefoundation/autoware/discussions/categories/q-a) to seek guidance from maintainers.
+2. **Use Clear, Concise Titles**: Clearly summarize the issue or task in the title for quick identification.
+3. **Provide Detailed Descriptions**: Include all necessary details to understand the context and scope of the issue. Attach screenshots, error logs, and code snippets where applicable.
+4. **Tag Relevant Contributors**: Mention contributors or teams that might be impacted by or interested in the issue.
+
+### Linking issues and pull requests
+
+When you start working on an issue, link the related pull request to the issue by mentioning the issue number.
+This helps maintain a clear and traceable development history.
 
 !!! warning
 
-    Do not create issues for questions or unconfirmed bugs. If such issues are created, maintainers will transfer them to GitHub Discussions.
-
-If you want to fix the bug by yourself, discuss the approach with maintainers and submit a pull request.
+    GitHub Issues is not for questions or unconfirmed bugs. If an issue is created for such purposes,
+    it will likely be transferred to GitHub Discussions for further clarification.
 
 ## Discord
 

--- a/docs/support/support-guidelines.md
+++ b/docs/support/support-guidelines.md
@@ -33,7 +33,7 @@ Before creating a new issue or question, check if someone else has already repor
 
 - **[Issues](https://github.com/autowarefoundation/autoware/issues)**
 
-  Note that Autoware has multiple repositories listed in [autoware.repos](https://github.com/autowarefoundation/autoware/blob/main/autoware.repos). 
+  Note that Autoware has multiple repositories listed in [autoware.repos](https://github.com/autowarefoundation/autoware/blob/main/autoware.repos).
   It is recommended to search across all repositories.
 
 - **[Questions](https://github.com/autowarefoundation/autoware/discussions/categories/q-a)**
@@ -70,7 +70,7 @@ If you find out that some information is wrong, unclear, or missing in Autoware 
 [GitHub discussions page](https://github.com/orgs/autowarefoundation/discussions) is the primary place for asking questions and discussing topics related to Autoware.
 
 | Category                                                                                                               | Description                                                             |
-|:-----------------------------------------------------------------------------------------------------------------------|:------------------------------------------------------------------------|
+| :--------------------------------------------------------------------------------------------------------------------- | :---------------------------------------------------------------------- |
 | [Announcements](https://github.com/orgs/autowarefoundation/discussions/categories/announcements)                       | Official updates and news from the Autoware maintainers                 |
 | [Design](https://github.com/orgs/autowarefoundation/discussions/categories/design)                                     | Discussions on Autoware system and software design                      |
 | [Feature requests](https://github.com/orgs/autowarefoundation/discussions/categories/feature-requests)                 | Suggestions for new features and improvements                           |

--- a/docs/support/support-guidelines.md
+++ b/docs/support/support-guidelines.md
@@ -120,6 +120,8 @@ When creating a new issue, use the following guidelines:
 When you start working on an issue, link the related pull request to the issue by mentioning the issue number.
 This helps maintain a clear and traceable development history.
 
+For more details, see the [Pull Request Guidelines page](../contributing/pull-request-guidelines/index.md).
+
 !!! warning
 
     GitHub Issues is not for questions or unconfirmed bugs. If an issue is created for such purposes,


### PR DESCRIPTION
## Description

I've made a lot of improvements on the support-guidelines page of the documentation.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
