### PR TITLE
fix(rosbag-replay-simulation): fix link for gdown

### DIFF
--- a/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
+++ b/docs/tutorials/ad-hoc-simulation/rosbag-replay-simulation.md
@@ -16,7 +16,7 @@
    - You can also download [the rosbag files](https://drive.google.com/file/d/1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP/view?usp=sharing) manually.
 
    ```bash
-   gdown -O ~/autoware_map/ 'https://drive.google.com/file/d/1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP'
+   gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP'
    unzip -d ~/autoware_map/ ~/autoware_map/sample-rosbag.zip
    ```
 


### PR DESCRIPTION
## Description
There was a mistake when I updated the link for rosbags during migration from autoware_auto_msgs to autoware_msgs in https://github.com/autowarefoundation/autoware-documentation/pull/563

Users cannot download the rosbag with gdown with the current link.
This PR will fix that issue.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
