### PR TITLE
fix(topic-message-handling): correct the first sample code

### DIFF
--- a/docs/contributing/coding-guidelines/ros-nodes/topic-message-handling/index.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/topic-message-handling/index.md
@@ -26,7 +26,7 @@ The sample code given below shows that `Subscription->take()` method is called d
 In this case, a topic message is retrieved from the subscription queue, the queue embedded in the subscription object, instead of using a callback function. To be precise, you have to program your code so that a callback function is not automatically called.
 
 ```c++
-  SteeringReport::SharedPtr msg;
+  SteeringReport msg;
   rclcpp::MessageInfo msg_info;
   if (sub_->take(msg, msg_info)) {
     // processing and publishing after this


### PR DESCRIPTION
## Description

According to the https://discourse.ros.org/t/new-documentation-on-how-to-take-a-message-from-a-subscriber-without-executing-a-callback-function/38430/5?u=takamine , a reference to the value should be given to the `take` method.


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
