### PR TITLE
docs(ad-api): release adapi v1.5.0

### DIFF
--- a/docs/design/autoware-interfaces/ad-api/list/api/routing/change_route.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/routing/change_route.md
@@ -18,7 +18,7 @@ type:
 
 {% extends 'design/autoware-interfaces/templates/autoware-interface.jinja2' %}
 {% block description %}
-Same as {{ link_ad_api('/api/routing/change_route') }}, but change the route while driving.
+Same as {{ link_ad_api('/api/routing/set_route') }}, but change the route while driving.
 This API only accepts the route when the route state is SET.
 In any other state, set the route first or wait for the route change to complete.
 {% endblock %}

--- a/docs/design/autoware-interfaces/ad-api/list/api/routing/change_route.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/routing/change_route.md
@@ -1,6 +1,6 @@
 ---
 title: /api/routing/change_route
-status: not released
+status: v1.5.0
 method: function call
 type:
   name: autoware_adapi_v1_msgs/srv/SetRoute

--- a/docs/design/autoware-interfaces/ad-api/list/api/routing/change_route_points.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/routing/change_route_points.md
@@ -18,7 +18,7 @@ type:
 
 {% extends 'design/autoware-interfaces/templates/autoware-interface.jinja2' %}
 {% block description %}
-Same as {{ link_ad_api('/api/routing/change_route_points') }}, but change the route while driving.
+Same as {{ link_ad_api('/api/routing/set_route_points') }}, but change the route while driving.
 This API only accepts the route when the route state is SET.
 In any other state, set the route first or wait for the route change to complete.
 {% endblock %}

--- a/docs/design/autoware-interfaces/ad-api/list/api/routing/change_route_points.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/routing/change_route_points.md
@@ -1,6 +1,6 @@
 ---
 title: /api/routing/change_route_points
-status: not released
+status: v1.5.0
 method: function call
 type:
   name: autoware_adapi_v1_msgs/srv/SetRoutePoints

--- a/docs/design/autoware-interfaces/ad-api/list/index.md
+++ b/docs/design/autoware-interfaces/ad-api/list/index.md
@@ -21,8 +21,8 @@
 | [/api/planning/cooperation/set_policies](./api/planning/cooperation/set_policies.md)             | not released |
 | [/api/planning/steering_factors](./api/planning/steering_factors.md)                             | not released |
 | [/api/planning/velocity_factors](./api/planning/velocity_factors.md)                             | not released |
-| [/api/routing/change_route](./api/routing/change_route.md)                                       | not released |
-| [/api/routing/change_route_points](./api/routing/change_route_points.md)                         | not released |
+| [/api/routing/change_route](./api/routing/change_route.md)                                       | v1.5.0       |
+| [/api/routing/change_route_points](./api/routing/change_route_points.md)                         | v1.5.0       |
 | [/api/routing/clear_route](./api/routing/clear_route.md)                                         | v1.0.0       |
 | [/api/routing/route](./api/routing/route.md)                                                     | v1.0.0       |
 | [/api/routing/set_route](./api/routing/set_route.md)                                             | v1.0.0       |

--- a/docs/design/autoware-interfaces/ad-api/release.md
+++ b/docs/design/autoware-interfaces/ad-api/release.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## v1.5.0
+
+- [New] Add {{ link_ad_api('/api/routing/change_route_points') }}
+- [New] Add {{ link_ad_api('/api/routing/change_route') }}
+
 ## v1.4.0
 
 - [New] Add {{ link_ad_api('/api/vehicle/status') }}


### PR DESCRIPTION
## Description

Update AD API documents for v1.5.0 release. [See release note page for details.](https://autowarefoundation.github.io/autoware-documentation/pr-595/design/autoware-interfaces/ad-api/release/)

Related link: https://github.com/autowarefoundation/autoware.universe/pull/8267

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
