### PR TITLE
chore: add autoware_ prefix to the URL of gnss_poser

### DIFF
--- a/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
@@ -4,6 +4,8 @@ This document describes the directory structure of ROS nodes within Autoware.
 
 We'll use the package `autoware_gnss_poser` as an example.
 
+**Note that this example does not reflect the actual `autoware_gnss_poser`, and has extra files and directories to demonstrate all posssible package structure.**
+
 ## C++ package
 
 ### Entire structure

--- a/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
@@ -4,7 +4,7 @@ This document describes the directory structure of ROS nodes within Autoware.
 
 We'll use the package `autoware_gnss_poser` as an example.
 
-**Note that this example does not reflect the actual `autoware_gnss_poser`, and has extra files and directories to demonstrate all posssible package structure.**
+**Note that this example does not reflect the actual `autoware_gnss_poser`, and has extra files and directories to demonstrate all possible package structure.**
 
 ## C++ package
 

--- a/docs/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-model/creating-sensor-model/index.md
+++ b/docs/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-model/creating-sensor-model/index.md
@@ -901,11 +901,11 @@ We will set up the GNSS/INS sensor launches at `gnss.launch.xml`.
 The default GNSS sensor options at [`sample_sensor_kit_launch`](https://github.com/autowarefoundation/sample_sensor_kit_launch/blob/main/sample_sensor_kit_launch/launch/gnss.launch.xml) for [u-blox](https://www.u-blox.com/en/)
 and [septentrio](https://www.septentrio.com/en) is included in `gnss.launch.xml`,
 so If we use other sensors as GNSS/INS receiver, we need to add it here.
-Moreover, [gnss_poser](https://github.com/autowarefoundation/autoware.universe/tree/main/sensing/gnss_poser) package launches here,
+Moreover, [gnss_poser](https://github.com/autowarefoundation/autoware.universe/tree/main/sensing/autoware_gnss_poser) package launches here,
 we will use this package for the pose source of our vehicle at localization initialization but remember,
 your sensor_driver must provide [autoware gnss orientation message](https://github.com/autowarefoundation/autoware_msgs/blob/main/autoware_sensing_msgs/msg/GnssInsOrientationStamped.msg) for this node.
 If you are ready with your GNSS/INS driver,
-you must set `navsatfix_topic_name` and `orientation_topic_name` variables at this launch file for [gnss_poser](https://github.com/autowarefoundation/autoware.universe/tree/main/sensing/gnss_poser) arguments.
+you must set `navsatfix_topic_name` and `orientation_topic_name` variables at this launch file for [gnss_poser](https://github.com/autowarefoundation/autoware.universe/tree/main/sensing/autoware_gnss_poser) arguments.
 For Example, necessary modifications for <YOUR-GNSS-SENSOR> should be like this:
 
 ```diff
@@ -978,7 +978,7 @@ our `gnss.launch.xml` for tutorial vehicle should be like this file
         </group>
 
         <!-- NavSatFix to MGRS Pose -->
-        <include file="$(find-pkg-share gnss_poser)/launch/gnss_poser.launch.xml">
+        <include file="$(find-pkg-share autoware_gnss_poser)/launch/gnss_poser.launch.xml">
           <arg name="input_topic_fix" value="$(var navsatfix_topic_name)"/>
           <arg name="input_topic_orientation" value="$(var orientation_topic_name)"/>
 


### PR DESCRIPTION
## Description

This PR is a counterpart of https://github.com/autowarefoundation/autoware.universe/pull/8323 in autoware.universe.
The URL to gnss_poser is revised since the package name will change.
**This PR should be merged after merging https://github.com/autowarefoundation/autoware.universe/pull/8323.**

Plus, I also wrote a caution that the example in directory-structure doesn't match the actual gnss_poser package.

**TODO**: Rename class name and file name in gnss_poser in autoware.universe to match the example.
- gnss_poser_core.cpp/hpp -> gnss_poser_node.cpp/hpp
- autoware::gnss_poser::GNSSPoser -> autoware::gnss_poser::GNSSPoserNode

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
