### PR TITLE
feat(ad-api): add restrictions and options

### DIFF
--- a/docs/design/autoware-interfaces/ad-api/features/routing.md
+++ b/docs/design/autoware-interfaces/ad-api/features/routing.md
@@ -35,3 +35,7 @@ See the sections below for supported options and details.
 ### allow_goal_modification
 
 **[v1.1.0]** Autoware tries to look for an alternate goal when goal is unreachable (e.g., when there is an obstacle on the given goal). When setting a route from the API, applications can choose whether they allow Autoware to adjust goal pose in such situation. When set false, Autoware may get stuck until the given goal becomes reachable.
+
+### allow_while_using_route
+
+**[v1.6.0]** This option only affects the route change APIs. Autoware accepts new route even while the vehicle is using the current route. The route is only changed if it is safe to transition to the new route. When set false, the APIs always fail when the using the route.

--- a/docs/design/autoware-interfaces/ad-api/features/routing.md
+++ b/docs/design/autoware-interfaces/ad-api/features/routing.md
@@ -38,4 +38,4 @@ See the sections below for supported options and details.
 
 ### allow_while_using_route
 
-**[v1.6.0]** This option only affects the route change APIs. Autoware accepts new route even while the vehicle is using the current route. The route is only changed if it is safe to transition to the new route. When set false, the APIs always fail when the using the route.
+**[v1.6.0]** This option only affects the route change APIs. Autoware accepts new route even while the vehicle is using the current route. The APIs fail if it cannot safely transition to new route. When set false, the APIs always fail when the vehicle is using the route.

--- a/docs/design/autoware-interfaces/ad-api/list/api/routing/clear_route.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/routing/clear_route.md
@@ -11,5 +11,5 @@ type:
 
 {% extends 'design/autoware-interfaces/templates/autoware-interface.jinja2' %}
 {% block description %}
-Clear the route.
+Clear the route. This API fails when the vehicle is using the route.
 {% endblock %}

--- a/docs/design/autoware-interfaces/ad-api/list/api/vehicle/doors/command.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/vehicle/doors/command.md
@@ -17,4 +17,5 @@ type:
 {% extends 'design/autoware-interfaces/templates/autoware-interface.jinja2' %}
 {% block description %}
 Set the door command. This API is only available if the vehicle supports software door control.
+This API fails if the door cannot be opened or closed safely.
 {% endblock %}

--- a/docs/design/autoware-interfaces/ad-api/list/api/vehicle/doors/command.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/vehicle/doors/command.md
@@ -17,5 +17,5 @@ type:
 {% extends 'design/autoware-interfaces/templates/autoware-interface.jinja2' %}
 {% block description %}
 Set the door command. This API is only available if the vehicle supports software door control.
-This API fails if the door cannot be opened or closed safely.
+This API fails if the doors cannot be opened or closed safely.
 {% endblock %}

--- a/docs/design/autoware-interfaces/ad-api/list/api/vehicle/status.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/vehicle/status.md
@@ -1,7 +1,7 @@
 ---
 title: /api/vehicle/status
 status: v1.4.0
-method: notification
+method: realtime stream
 type:
   name: autoware_adapi_v1_msgs/msg/VehicleStatus
   msg:

--- a/docs/design/autoware-interfaces/ad-api/release.md
+++ b/docs/design/autoware-interfaces/ad-api/release.md
@@ -1,5 +1,12 @@
 # Release notes
 
+## v1.6.0 (Not released)
+
+- [Change] Fix communication method of {{ link_ad_api('/api/vehicle/status') }}
+- [Change] Add options to [the routing API](./features/routing.md)
+- [Change] Add restrictions to {{ link_ad_api('/api/routing/clear_route') }}
+- [Change] Add restrictions to {{ link_ad_api('/api/vehicle/doors/command') }}
+
 ## v1.5.0
 
 - [New] Add {{ link_ad_api('/api/routing/change_route_points') }}

--- a/docs/design/autoware-interfaces/ad-api/types/autoware_adapi_v1_msgs/msg/RouteOption.md
+++ b/docs/design/autoware-interfaces/ad-api/types/autoware_adapi_v1_msgs/msg/RouteOption.md
@@ -10,7 +10,11 @@ used:
 {% block definition %}
 
 ```txt
+# Please refer to the following pages for details on each option.
+# https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-interfaces/ad-api/features/routing/
+
 bool allow_goal_modification
+bool allow_while_using_route
 ```
 
 {% endblock %}

--- a/yaml/autoware-interfaces.yaml
+++ b/yaml/autoware-interfaces.yaml
@@ -129,6 +129,7 @@ types:
   autoware_adapi_v1_msgs/msg/RouteOption:
     msg:
       allow_goal_modification: bool
+      allow_while_using_route: bool
   autoware_adapi_v1_msgs/msg/RoutePrimitive:
     msg:
       id: int64


### PR DESCRIPTION
## Description

Add restrictions and options for safety. Related to https://github.com/autowarefoundation/autoware_adapi_msgs/pull/61.
See the [release notes](https://autowarefoundation.github.io/autoware-documentation/pr-602/design/autoware-interfaces/ad-api/release/) for v1.6.0 for details. 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
