### PR TITLE
chore(coding_guidelines): match the example to the actual autoware_gnss_poser

### DIFF
--- a/docs/contributing/coding-guidelines/ros-nodes/class-design.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/class-design.md
@@ -21,10 +21,10 @@ namespace autoware::gnss_poser
 #### `gnss_poser_node.hpp`
 
 ```cpp
-class GNSSPoserNode : public rclcpp::Node
+class GNSSPoser : public rclcpp::Node
 {
   public:
-    explicit GNSSPoserNode(const rclcpp::NodeOptions & node_options);
+    explicit GNSSPoser(const rclcpp::NodeOptions & node_options);
   ...
 }
 ```
@@ -32,7 +32,7 @@ class GNSSPoserNode : public rclcpp::Node
 #### `gnss_poser_node.cpp`
 
 ```cpp
-GNSSPoserNode::GNSSPoserNode(const rclcpp::NodeOptions & node_options)
+GNSSPoser::GNSSPoser(const rclcpp::NodeOptions & node_options)
 : Node("gnss_poser", node_options)
 {
   ...
@@ -56,7 +56,7 @@ GNSSPoserNode::GNSSPoserNode(const rclcpp::NodeOptions & node_options)
 } // namespace autoware::gnss_poser
 
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(autoware::gnss_poser::GNSSPoserNode)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::gnss_poser::GNSSPoser)
 ```
 
 - The component should be registered at the end of the `gnss_poser_node.cpp` file, outside the namespaces.

--- a/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
@@ -96,7 +96,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "autoware::gnss_poser::GNSSPoserNode"
+  PLUGIN "autoware::gnss_poser::GNSSPoser"
   EXECUTABLE ${PROJECT_NAME}_node
 )
 ```
@@ -114,7 +114,7 @@ Use of standalone executables **should be limited** to cases where specific need
 
 Assuming:
 
-- `src/gnss_poser.cpp` has the `GNSSPoserNode` class.
+- `src/gnss_poser.cpp` has the `GNSSPoser` class.
 - `src/gnss_poser_node.cpp` has the `main` function.
 - There is no composable node component registration.
 

--- a/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/directory-structure.md
@@ -4,7 +4,7 @@ This document describes the directory structure of ROS nodes within Autoware.
 
 We'll use the package `autoware_gnss_poser` as an example.
 
-**Note that this example does not reflect the actual `autoware_gnss_poser`, and has extra files and directories to demonstrate all possible package structure.**
+**Note that this example does not reflect the actual `autoware_gnss_poser` and includes extra files and directories to demonstrate all possible package structures.**
 
 ## C++ package
 

--- a/docs/how-to-guides/integrating-autoware/launch-autoware/index.md
+++ b/docs/how-to-guides/integrating-autoware/launch-autoware/index.md
@@ -191,7 +191,7 @@ ros2 launch autoware_launch autoware_launch.launch.xml map_path:=<YOUR-MAP-PATH>
 ```
 
 After launching Autoware, we need to initialize our vehicle on our map.
-If you set [gnss_poser](https://autowarefoundation.github.io/autoware.universe/main/sensing/gnss_poser/) for your GNSS/INS sensor at `gnss.launch.xml`,
+If you set [gnss_poser](https://autowarefoundation.github.io/autoware.universe/main/sensing/autoware_gnss_poser/) for your GNSS/INS sensor at `gnss.launch.xml`,
 then gnss_poser will send pose for initialization.
 If you don't have a GNSS sensor, then you need to set initial pose manually.
 


### PR DESCRIPTION
## Description

[In the coding guidelines, autoware_gnss_poser is used as an example](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/).

However, there are some lines that mismatch to the actual [`autoware_gnss_poser`](https://github.com/autowarefoundation/autoware.universe/tree/main/sensing/autoware_gnss_poser), so I fixed them in this PR.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
