### PR TITLE
fix: fix adapi usecase links

### DIFF
--- a/docs/design/autoware-interfaces/ad-api/use-cases/change-operation-mode.md
+++ b/docs/design/autoware-interfaces/ad-api/use-cases/change-operation-mode.md
@@ -2,7 +2,7 @@
 
 ## Related API
 
-- Operation mode
+- [Operation mode](../features/operation_mode.md)
 
 ## Sequence
 

--- a/docs/design/autoware-interfaces/ad-api/use-cases/drive-designated-position.md
+++ b/docs/design/autoware-interfaces/ad-api/use-cases/drive-designated-position.md
@@ -2,8 +2,8 @@
 
 ## Related API
 
-- Driving
-- Route
+- [Operation mode](../features/operation_mode.md)
+- [Routing](../features/routing.md)
 
 ## Sequence
 

--- a/docs/design/autoware-interfaces/ad-api/use-cases/get-on-off.md
+++ b/docs/design/autoware-interfaces/ad-api/use-cases/get-on-off.md
@@ -2,7 +2,7 @@
 
 ## Related API
 
-- Door
+- [Vehicle doors](../features/vehicle-doors.md)
 
 ## Sequence
 

--- a/docs/design/autoware-interfaces/ad-api/use-cases/initialize-pose.md
+++ b/docs/design/autoware-interfaces/ad-api/use-cases/initialize-pose.md
@@ -2,7 +2,7 @@
 
 ## Related API
 
-- Pose
+- [Localization](../features/localization.md)
 
 ## Sequence
 

--- a/docs/design/autoware-interfaces/ad-api/use-cases/launch-terminate.md
+++ b/docs/design/autoware-interfaces/ad-api/use-cases/launch-terminate.md
@@ -2,8 +2,7 @@
 
 ## Related API
 
-- Interface
-- Launcher
+- T.B.D.
 
 ## Sequence
 

--- a/docs/design/autoware-interfaces/ad-api/use-cases/sequence/drive-designated-position.plantuml
+++ b/docs/design/autoware-interfaces/ad-api/use-cases/sequence/drive-designated-position.plantuml
@@ -3,7 +3,7 @@
 skinparam ParticipantPadding 25
 participant "User" as user
 participant "Application" as system
-participant "AD API (drive)" as api_drive
+participant "AD API (op mode)" as api_drive
 participant "AD API (route)" as api_route
 
 api_drive --> system: notify that the vehicle is not driving


### PR DESCRIPTION
## Description

Fix adapi use case page links.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
