### PR TITLE
docs: fix `architecture_type` for scenario_simulator_v2

### DIFF
--- a/docs/tutorials/scenario-simulation/planning-simulation/random-test-simulation.md
+++ b/docs/tutorials/scenario-simulation/planning-simulation/random-test-simulation.md
@@ -18,7 +18,7 @@
 
    ```bash
    ros2 launch random_test_runner random_test.launch.py \
-     architecture_type:=awf/universe \
+     architecture_type:=awf/universe/20240605 \
      sensor_model:=sample_sensor_kit \
      vehicle_model:=sample_vehicle
    ```

--- a/docs/tutorials/scenario-simulation/planning-simulation/scenario-test-simulation.md
+++ b/docs/tutorials/scenario-simulation/planning-simulation/scenario-test-simulation.md
@@ -18,7 +18,7 @@
 
    ```bash
    ros2 launch scenario_test_runner scenario_test_runner.launch.py \
-     architecture_type:=awf/universe \
+     architecture_type:=awf/universe/20240605 \
      record:=false \
      scenario:='$(find-pkg-share scenario_test_runner)/scenario/sample.yaml' \
      sensor_model:=sample_sensor_kit \


### PR DESCRIPTION
## Description

When using `scenario_simulator_v2`, for the latest Autoware, it is preffeered to specify `awf/universe/20240605` as the launch argument `architecture_type`.

The `architecture_type` parameter of `scenario_simulator_v2` is mainly used to switch traffic light messages, which change frequently in recent Autoware.

For more details, see https://github.com/tier4/scenario_simulator_v2/pull/1277.

This is related to issue below
- https://github.com/tier4/scenario_simulator_v2/issues/1374

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
