### PR TITLE
fix: update github link of ndt_scan_matcher

### DIFF
--- a/docs/how-to-guides/integrating-autoware/launch-autoware/localization/index.md
+++ b/docs/how-to-guides/integrating-autoware/launch-autoware/localization/index.md
@@ -36,7 +36,7 @@ The current localization launcher implemented by TIER IV supports multiple local
 `tier4_localization_component.launch.xml` has two arguments to select which estimators to launch:
 
 - **`pose_source:`** This argument specifies the pose_estimator, currently supporting `ndt` (default), `yabloc`, `artag` and `eagleye` for localization.
-  By default, Autoware launches [ndt_scan_matcher](https://github.com/autowarefoundation/autoware.universe/tree/main/localization/ndt_scan_matcher) for pose estimator.
+  By default, Autoware launches [ndt_scan_matcher](https://github.com/autowarefoundation/autoware.universe/tree/main/localization/autoware_ndt_scan_matcher) for pose estimator.
   You can use YabLoc as a camera-based localization method.
   For more details on YabLoc,
   please refer to the [README of YabLoc](https://github.com/autowarefoundation/autoware.universe/blob/main/localization/yabloc/README.md) in autoware.universe.

--- a/docs/how-to-guides/others/an-example-procedure-for-adding-and-evaluating-a-new-node.md
+++ b/docs/how-to-guides/others/an-example-procedure-for-adding-and-evaluating-a-new-node.md
@@ -39,7 +39,7 @@ When developing a new node, it could be beneficial to reference a package that i
 
 It is advisable to thoroughly read the [Design page](https://autowarefoundation.github.io/autoware-documentation/main/design/), contemplate the addition or replacement of nodes in Autoware, and then implement your solution.
 
-For example, a node doing NDT, a LiDAR-based localization method, is [ndt_scan_matcher](https://github.com/autowarefoundation/autoware.universe/tree/main/localization/ndt_scan_matcher).
+For example, a node doing NDT, a LiDAR-based localization method, is [ndt_scan_matcher](https://github.com/autowarefoundation/autoware.universe/tree/main/localization/autoware_ndt_scan_matcher).
 If you want to replace this with a different approach, implement a node which produces the same topics and provides the same services.
 
 `ndt_scan_matcher` is launched as [pose_estimator](https://github.com/autowarefoundation/autoware.universe/blob/main/launch/tier4_localization_launch/launch/pose_estimator/pose_estimator.launch.xml), so it is necessary to replace the launch file as well.


### PR DESCRIPTION
## Description
This PR will change the github link of `ndt_scan_matcher` due to the change in https://github.com/autowarefoundation/autoware.universe/pull/8904 .

This PR should be merged after merging the https://github.com/autowarefoundation/autoware.universe/pull/8904 in autoware.universe.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
