### PR TITLE
docs: add apt update/upgrade to workspace install/update instructions

### DIFF
--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -126,7 +126,7 @@ Inside the container, you can run the Autoware tutorials by following these link
 > and re-importing all dependencies may be necessary:
 >
 > ```bash
-> rm -rf src
+> rm -rf src/*
 > vcs import src < autoware.repos
 > ```
 

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -90,11 +90,12 @@ Inside the container, you can run the Autoware tutorials by following these link
 
 2. Update dependent ROS packages.
 
-   The dependency of Autoware may change after the Docker image was created.
-   In that case, you need to run the following commands to update the dependency.
+   The dependencies of Autoware may have changed after the Docker image was created.
+   In that case, you need to run the following commands to update the dependencies.
 
    ```bash
-   sudo apt update
+   # Make sure all ros-$ROS_DISTRO-* packages are upgraded to their latest version
+   sudo apt update && sudo apt upgrade
    rosdep update
    rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
    ```
@@ -114,6 +115,19 @@ Inside the container, you can run the Autoware tutorials by following these link
 > git pull
 > vcs import src < autoware.repos
 > vcs pull src
+> # Make sure all ros-$ROS_DISTRO-* packages are upgraded to their latest version
+> sudo apt update && sudo apt upgrade
+> rosdep update
+> rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+> ```
+>
+> It might be the case that dependencies imported via `vcs import` have been moved/removed.
+> VCStool does not currently handle those cases, so if builds fail after `vcs import`, cleaning
+> and re-importing all dependencies may be necessary:
+>
+> ```bash
+> rm -rf src
+> vcs import src < autoware.repos
 > ```
 
 #### Using VS Code remote containers for development

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -88,6 +88,9 @@ sudo apt-get -y install git
 
    ```bash
    source /opt/ros/humble/setup.bash
+   # Make sure all previously installed ros-$ROS_DISTRO-* packages are upgraded to their latest version
+   sudo apt update && sudo apt upgrade
+   rosdep update
    rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
    ```
 
@@ -135,10 +138,21 @@ sudo apt-get -y install git
 
    For more information, refer to the [official documentation](https://github.com/dirk-thomas/vcstool).
 
+   It might be the case that dependencies imported via `vcs import` have been moved/removed.
+   VCStool does not currently handle those cases, so if builds fail after `vcs import`, cleaning
+   and re-importing all dependencies may be necessary:
+   ```bash
+   rm -rf src
+   vcs import src < autoware.repos
+   ```
+
 3. Install dependent ROS packages.
 
    ```bash
    source /opt/ros/humble/setup.bash
+   # Make sure all previously installed ros-$ROS_DISTRO-* packages are upgraded to their latest version
+   sudo apt update && sudo apt upgrade
+   rosdep update
    rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
    ```
 

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -141,6 +141,7 @@ sudo apt-get -y install git
    It might be the case that dependencies imported via `vcs import` have been moved/removed.
    VCStool does not currently handle those cases, so if builds fail after `vcs import`, cleaning
    and re-importing all dependencies may be necessary:
+
    ```bash
    rm -rf src
    vcs import src < autoware.repos

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -143,7 +143,7 @@ sudo apt-get -y install git
    and re-importing all dependencies may be necessary:
 
    ```bash
-   rm -rf src
+   rm -rf src/*
    vcs import src < autoware.repos
    ```
 


### PR DESCRIPTION
## Description

Added missing instructions to the following guides:
* Docker update
* Source install
* Source update

Specifically, `sudo apt update && sudo apt upgrade` were missing: `rosdep update` and `rosdep install` will not upgrade previously installed `ros-$ROS_DISTRO-*` packages (even when Autoware is expected to be built with newer versions), which often results in unexpected Autoware build failures.
From my experience in the last two weeks, following the instructions perfectly on a clean Autoware repo succeeded one out of five times mainly due to this issue.

I also added comments that for moved/removed dependencies in the `repos` files, `vcstool` will not sync correctly and result in duplicate or wrongly remaining packages, in which case the `src` directory has to be deleted and re-pulled.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
