### PR TITLE
fix: add autoware prefix to the map_loader

### DIFF
--- a/docs/contributing/testing-guidelines/integration-testing.md
+++ b/docs/contributing/testing-guidelines/integration-testing.md
@@ -70,16 +70,16 @@ The simplest scenario is a single node.
 In this case, the integration test is commonly referred to as a component test.
 
 To add a component test to an existing node,
-you can follow the example of the `lanelet2_map_loader` in the [`map_loader` package](https://github.com/autowarefoundation/autoware.universe/tree/main/map/map_loader)
+you can follow the example of the `lanelet2_map_loader` in the [`autoware_map_loader` package](https://github.com/autowarefoundation/autoware.universe/tree/main/map/autoware_map_loader)
 (added in [this PR](https://github.com/autowarefoundation/autoware.universe/pull/1056)).
 
-In [`package.xml`](https://github.com/autowarefoundation/autoware.universe/blob/main/map/map_loader/package.xml), add:
+In [`package.xml`](https://github.com/autowarefoundation/autoware.universe/blob/main/map/autoware_map_loader/package.xml), add:
 
 ```xml
 <test_depend>ros_testing</test_depend>
 ```
 
-In [`CMakeLists.txt`](https://github.com/autowarefoundation/autoware.universe/blob/main/map/map_loader/CMakeLists.txt),
+In [`CMakeLists.txt`](https://github.com/autowarefoundation/autoware.universe/blob/main/map/autoware_map_loader/CMakeLists.txt),
 add or modify the `BUILD_TESTING` section:
 
 ```cmake
@@ -106,7 +106,7 @@ To create a test,
 either read the [launch_testing quick-start example](https://github.com/ros2/launch/tree/master/launch_testing#quick-start-example),
 or follow the steps below.
 
-Taking [`test/lanelet2_map_loader_launch.test.py`](https://github.com/autowarefoundation/autoware.universe/blob/main/map/map_loader/test/lanelet2_map_loader_launch.test.py) as an example,
+Taking [`test/lanelet2_map_loader_launch.test.py`](https://github.com/autowarefoundation/autoware.universe/blob/main/map/autoware_map_loader/test/lanelet2_map_loader_launch.test.py) as an example,
 first dependencies are imported:
 
 ```python
@@ -122,7 +122,7 @@ import pytest
 ```
 
 Then a launch description is created to launch the node under test.
-Note that the [`test_map.osm`](https://github.com/autowarefoundation/autoware.universe/blob/main/map/map_loader/test/data/test_map.osm) file path is found and passed to the node,
+Note that the [`test_map.osm`](https://github.com/autowarefoundation/autoware.universe/blob/main/map/autoware_map_loader/test/data/test_map.osm) file path is found and passed to the node,
 something that cannot be done with the [smoke testing API](#smoke-tests):
 
 ```python
@@ -130,12 +130,12 @@ something that cannot be done with the [smoke testing API](#smoke-tests):
 def generate_test_description():
 
     lanelet2_map_path = os.path.join(
-        get_package_share_directory("map_loader"), "test/data/test_map.osm"
+        get_package_share_directory("autoware_map_loader"), "test/data/test_map.osm"
     )
 
     lanelet2_map_loader = Node(
-        package="map_loader",
-        executable="lanelet2_map_loader",
+        package="autoware_map_loader",
+        executable="autoware_lanelet2_map_loader",
         parameters=[{"lanelet2_map_path": lanelet2_map_path}],
     )
 
@@ -177,20 +177,20 @@ class TestProcessOutput(unittest.TestCase):
 Continuing the example from above, first build your package:
 
 ```console
-colcon build --packages-up-to map_loader
+colcon build --packages-up-to autoware_map_loader
 source install/setup.bash
 ```
 
 Then either execute the component test manually:
 
 ```console
-ros2 test src/universe/autoware.universe/map/map_loader/test/lanelet2_map_loader_launch.test.py
+ros2 test src/universe/autoware.universe/map/autoware_map_loader/test/lanelet2_map_loader_launch.test.py
 ```
 
 Or as part of testing the entire package:
 
 ```console
-colcon test --packages-select map_loader
+colcon test --packages-select autoware_map_loader
 ```
 
 Verify that the test is executed; e.g.
@@ -198,7 +198,7 @@ Verify that the test is executed; e.g.
 ```console
 $ colcon test-result --all --verbose
 ...
-build/map_loader/test_results/map_loader/test_lanelet2_map_loader_launch.test.py.xunit.xml: 1 test, 0 errors, 0 failures, 0 skipped
+build/autoware_map_loader/test_results/autoware_map_loader/test_lanelet2_map_loader_launch.test.py.xunit.xml: 1 test, 0 errors, 0 failures, 0 skipped
 ```
 
 ### Next steps

--- a/docs/design/autoware-architecture/map/index.md
+++ b/docs/design/autoware-architecture/map/index.md
@@ -69,7 +69,7 @@ The point cloud map must be supplied as a file with the following requirements:
 - Its resolution should be at least 0.2 m to yield reliable localization results.
 - It can be in either local or global coordinates, but must be in global coordinates (georeferenced) to use GNSS data for localization.
 
-For more details on divided map format, please refer to [the readme of `map_loader` in Autoware Universe](https://github.com/autowarefoundation/autoware.universe/blob/main/map/map_loader/README.md).
+For more details on divided map format, please refer to [the readme of `map_loader` in Autoware Universe](https://github.com/autowarefoundation/autoware.universe/blob/main/map/autoware_map_loader/README.md).
 
 !!! note
 

--- a/docs/how-to-guides/integrating-autoware/creating-maps/pointcloud-map-downsampling/index.md
+++ b/docs/how-to-guides/integrating-autoware/creating-maps/pointcloud-map-downsampling/index.md
@@ -5,7 +5,7 @@
 When your created point cloud map is either too dense or too large (i.e., exceeding 300 MB),
 you may want to downsample it for improved computational and memory efficiency.
 Also, you can consider using dynamic map loading with partial loading,
-please check [map_loader package](https://github.com/autowarefoundation/autoware.universe/tree/main/map/map_loader) for more information.
+please check [autoware_map_loader package](https://github.com/autowarefoundation/autoware.universe/tree/main/map/autoware_map_loader) for more information.
 
 At tutorial_vehicle implementation we will use the whole map,
 so we will downsample it with using [CloudCompare](https://www.cloudcompare.org/main.html).

--- a/docs/how-to-guides/others/using-divided-map.md
+++ b/docs/how-to-guides/others/using-divided-map.md
@@ -26,5 +26,5 @@ For playing rosbag to simulate Autoware, please refer to the instruction in [the
 ## Related links
 
 - For specific format definition of the divided map, please refer to [Map component design page](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-architecture/map/)
-- [The Readme of map_loader](https://github.com/autowarefoundation/autoware.universe/tree/main/map/map_loader) may be useful specific instructions for dividing maps
+- [The Readme of map_loader](https://github.com/autowarefoundation/autoware.universe/tree/main/map/autoware_map_loader) may be useful specific instructions for dividing maps
 - When dividing your own pointcloud map, you may use [pointcloud_divider](https://github.com/autowarefoundation/autoware_tools/tree/main/map/autoware_pointcloud_divider), which can divide the map as well as generating the compatible metadata


### PR DESCRIPTION
## Description
This PR will add autoware prefix to `map_loader` due to the change in https://github.com/autowarefoundation/autoware.universe/pull/8927 .

This PR should be merged after https://github.com/autowarefoundation/autoware.universe/pull/8927 merged .


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
