### PR TITLE
docs(installation): add information about nightly.repos

### DIFF
--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -88,6 +88,14 @@ Inside the container, you can run the Autoware tutorials by following these link
    vcs import src < autoware.repos
    ```
 
+   If you are an active developer, you may also want to pull the nightly repositories, which contain the latest updates:
+
+   ```bash
+   vcs import src < autoware-nightly.repos
+   ```
+
+   > ⚠️ Note: The nightly repositories are unstable and may contain bugs. Use them with caution.
+
 2. Update dependent ROS packages.
 
    The dependencies of Autoware may have changed after the Docker image was created.
@@ -114,6 +122,10 @@ Inside the container, you can run the Autoware tutorials by following these link
 > cd autoware
 > git pull
 > vcs import src < autoware.repos
+> 
+> # If you are using nightly repositories, also run the following command:
+> vcs import src < autoware-nightly.repos
+> 
 > vcs pull src
 > # Make sure all ros-$ROS_DISTRO-* packages are upgraded to their latest version
 > sudo apt update && sudo apt upgrade
@@ -128,6 +140,8 @@ Inside the container, you can run the Autoware tutorials by following these link
 > ```bash
 > rm -rf src/*
 > vcs import src < autoware.repos
+> # If you are using nightly repositories, import them as well.
+> vcs import src < autoware-nightly.repos
 > ```
 
 #### Using VS Code remote containers for development

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -122,10 +122,10 @@ Inside the container, you can run the Autoware tutorials by following these link
 > cd autoware
 > git pull
 > vcs import src < autoware.repos
-> 
+>
 > # If you are using nightly repositories, also run the following command:
 > vcs import src < autoware-nightly.repos
-> 
+>
 > vcs pull src
 > # Make sure all ros-$ROS_DISTRO-* packages are upgraded to their latest version
 > sudo apt update && sudo apt upgrade

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -82,7 +82,7 @@ sudo apt-get -y install git
    ```
 
    If you are an active developer, you may also want to pull the nightly repositories, which contain the latest updates:
-   
+
    ```bash
    vcs import src < autoware-nightly.repos
    ```
@@ -138,6 +138,7 @@ sudo apt-get -y install git
    ```
 
    > ⚠️ If you are using nightly repositories, you can also update them.
+   >
    > ```bash
    > vcs import src < autoware-nightly.repos
    > ```
@@ -165,10 +166,10 @@ sudo apt-get -y install git
    ```
 
    > ⚠️ If you are using nightly repositories, import them as well.
+   >
    > ```bash
    > vcs import src < autoware-nightly.repos
    > ```
-
 
 3. Install dependent ROS packages.
 

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -81,6 +81,14 @@ sudo apt-get -y install git
    vcs import src < autoware.repos
    ```
 
+   If you are an active developer, you may also want to pull the nightly repositories, which contain the latest updates:
+   
+   ```bash
+   vcs import src < autoware-nightly.repos
+   ```
+
+   > ⚠️ Note: The nightly repositories are unstable and may contain bugs. Use them with caution.
+
 2. Install dependent ROS packages.
 
    Autoware requires some ROS 2 packages in addition to the core components.
@@ -127,6 +135,14 @@ sudo apt-get -y install git
 
    ```bash
    vcs import src < autoware.repos
+   ```
+
+   > ⚠️ If you are using nightly repositories, you can also update them.
+   > ```bash
+   > vcs import src < autoware-nightly.repos
+   > ```
+
+   ```bash
    vcs pull src
    ```
 
@@ -147,6 +163,12 @@ sudo apt-get -y install git
    rm -rf src/*
    vcs import src < autoware.repos
    ```
+
+   > ⚠️ If you are using nightly repositories, import them as well.
+   > ```bash
+   > vcs import src < autoware-nightly.repos
+   > ```
+
 
 3. Install dependent ROS packages.
 


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/autoware/pull/5440
Has introduced the `autoware-nightly.repos`.

This PR adds this relevant information to the installation guides.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
