### PR TITLE
feat(ad-api): drop allow_while_using_route option

### DIFF
--- a/docs/design/autoware-interfaces/ad-api/features/routing.md
+++ b/docs/design/autoware-interfaces/ad-api/features/routing.md
@@ -35,7 +35,3 @@ See the sections below for supported options and details.
 ### allow_goal_modification
 
 **[v1.1.0]** Autoware tries to look for an alternate goal when goal is unreachable (e.g., when there is an obstacle on the given goal). When setting a route from the API, applications can choose whether they allow Autoware to adjust goal pose in such situation. When set false, Autoware may get stuck until the given goal becomes reachable.
-
-### allow_while_using_route
-
-**[v1.6.0]** This option only affects the route change APIs. Autoware accepts new route even while the vehicle is using the current route. The APIs fail if it cannot safely transition to new route. When set false, the APIs always fail when the vehicle is using the route.

--- a/docs/design/autoware-interfaces/ad-api/release.md
+++ b/docs/design/autoware-interfaces/ad-api/release.md
@@ -3,7 +3,6 @@
 ## v1.6.0 (Not released)
 
 - [Change] Fix communication method of {{ link_ad_api('/api/vehicle/status') }}
-- [Change] Add options to [the routing API](./features/routing.md)
 - [Change] Add restrictions to {{ link_ad_api('/api/routing/clear_route') }}
 - [Change] Add restrictions to {{ link_ad_api('/api/vehicle/doors/command') }}
 

--- a/docs/design/autoware-interfaces/ad-api/types/autoware_adapi_v1_msgs/msg/RouteOption.md
+++ b/docs/design/autoware-interfaces/ad-api/types/autoware_adapi_v1_msgs/msg/RouteOption.md
@@ -14,7 +14,6 @@ used:
 # https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-interfaces/ad-api/features/routing/
 
 bool allow_goal_modification
-bool allow_while_using_route
 ```
 
 {% endblock %}

--- a/yaml/autoware-interfaces.yaml
+++ b/yaml/autoware-interfaces.yaml
@@ -129,7 +129,6 @@ types:
   autoware_adapi_v1_msgs/msg/RouteOption:
     msg:
       allow_goal_modification: bool
-      allow_while_using_route: bool
   autoware_adapi_v1_msgs/msg/RoutePrimitive:
     msg:
       id: int64


### PR DESCRIPTION
## Description

Drop allow_while_using_route option. The restrictions added to clear_route make the same judgment as this option, so it is thought that it can be substituted with clear_route and set_route. We will reconsider whether chante_route needs an option.

Related: https://github.com/autowarefoundation/autoware_adapi_msgs/pull/71

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The Reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
