### PR TITLE
Fix AD COMPUTERs indent alignment

### DIFF
--- a/docs/reference-hw/index.md
+++ b/docs/reference-hw/index.md
@@ -11,9 +11,9 @@ The documents consists of the sections listed below:
 - AD COMPUTERs
 
   - ADLINK In-Vehicle Computers
-    - NXP In-Vehicle Computers
-    - Neousys In-Vehicle Computers
-    - Crystal Rugged In-Vehicle Computers
+  - NXP In-Vehicle Computers
+  - Neousys In-Vehicle Computers
+  - Crystal Rugged In-Vehicle Computers
 
 - LiDARs
 


### PR DESCRIPTION
## Description

When you look the following AD Computers page, all computers are placed in parallel, but not in its top page.

https://autowarefoundation.github.io/autoware-documentation/main/reference-hw/ad-computers/

This PR resolves the indent alignment of them.

## How was this PR tested?

n/a

## Notes for reviewers

None.

## Effects on system behavior

None.
