### PR TITLE
docs(ad-api): release adapi v1.7.0

### DIFF
--- a/docs/design/autoware-interfaces/ad-api/release.md
+++ b/docs/design/autoware-interfaces/ad-api/release.md
@@ -1,6 +1,10 @@
 # Release notes
 
-## v1.6.0 (Not released)
+## v1.7.0
+
+- [Chore] Change the messages for the prototype implementation.
+
+## v1.6.0
 
 - [Change] Fix communication method of {{ link_ad_api('/api/vehicle/status') }}
 - [Change] Add restrictions to {{ link_ad_api('/api/routing/clear_route') }}


### PR DESCRIPTION
## Description

Update AD API documents for v1.7.0 release. [See release note page for details.](https://autowarefoundation.github.io/autoware-documentation/pr-646/design/autoware-interfaces/ad-api/release/)

## How was this PR tested?

None

## Notes for reviewers

None.

## Effects on system behavior

None.
