### PR TITLE
refactor: added documentation about the extra packages

### DIFF
--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -101,6 +101,12 @@ Inside the container, you can run the Autoware tutorials by following these link
 
    > ⚠️ Note: The nightly repositories are unstable and may contain bugs. Use them with caution.
 
+   Optionally, you may also download the extra repositories that contain drivers for specific hardware, but they are not necessary for building and running Autoware:
+
+   ```bash
+   vcs import src < extra-packages.repos
+   ```
+
 2. Update dependent ROS packages.
 
    The dependencies of Autoware may have changed after the Docker image was created.

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -89,6 +89,12 @@ sudo apt-get -y install git
 
    > ⚠️ Note: The nightly repositories are unstable and may contain bugs. Use them with caution.
 
+   Optionally, you may also download the extra repositories that contain drivers for specific hardware, but they are not necessary for building and running Autoware:
+
+   ```bash
+   vcs import src < extra-packages.repos
+   ```
+
 2. Install dependent ROS packages.
 
    Autoware requires some ROS 2 packages in addition to the core components.


### PR DESCRIPTION
## Description

This PR adds documentation on how to download the extra repositories now that `tamagawa_imu_driver` and `pacmod_interfaces` are not downloaded automatically from the `autoware.repos` file.

See https://github.com/autowarefoundation/autoware/issues/3366

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
