### PR TITLE
docs(ad-api): release adapi v1.8.0

### DIFF
--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/acceleration.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/acceleration.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/local/command/acceleration
-status: not released
+status: v1.8.0
 method: realtime stream
 type:
   name: autoware_adapi_v1_msgs/msg/AccelerationCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/gear.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/gear.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/local/command/gear
-status: not released
+status: v1.8.0
 method: notification
 type:
   name: autoware_adapi_v1_msgs/msg/GearCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/hazard_lights.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/hazard_lights.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/local/command/hazard_lights
-status: not released
+status: v1.8.0
 method: notification
 type:
   name: autoware_adapi_v1_msgs/msg/HazardLightsCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/pedals.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/pedals.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/local/command/pedals
-status: not released
+status: v1.8.0
 method: realtime stream
 type:
   name: autoware_adapi_v1_msgs/msg/PedalsCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/steering.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/steering.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/local/command/steering
-status: not released
+status: v1.8.0
 method: realtime stream
 type:
   name: autoware_adapi_v1_msgs/msg/SteeringCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/turn_indicators.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/turn_indicators.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/local/command/turn_indicators
-status: not released
+status: v1.8.0
 method: notification
 type:
   name: autoware_adapi_v1_msgs/msg/TurnIndicatorsCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/velocity.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/local/command/velocity.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/local/command/velocity
-status: not released
+status: v1.8.0
 method: realtime stream
 type:
   name: autoware_adapi_v1_msgs/msg/VelocityCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/local/control_mode/list.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/local/control_mode/list.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/local/control_mode/list
-status: not released
+status: v1.8.0
 method: function call
 type:
   name: autoware_adapi_v1_msgs/srv/ListManualControlMode

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/local/control_mode/select.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/local/control_mode/select.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/local/control_mode/select
-status: not released
+status: v1.8.0
 method: function call
 type:
   name: autoware_adapi_v1_msgs/srv/SelectManualControlMode

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/local/control_mode/status.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/local/control_mode/status.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/local/control_mode/status
-status: not released
+status: v1.8.0
 method: notification
 type:
   name: autoware_adapi_v1_msgs/msg/ManualControlModeStatus

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/local/operator/heartbeat.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/local/operator/heartbeat.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/local/operator/heartbeat
-status: not released
+status: v1.8.0
 method: realtime stream
 type:
   name: autoware_adapi_v1_msgs/msg/ManualOperatorHeartbeat

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/acceleration.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/acceleration.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/remote/command/acceleration
-status: not released
+status: v1.8.0
 method: realtime stream
 type:
   name: autoware_adapi_v1_msgs/msg/AccelerationCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/gear.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/gear.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/remote/command/gear
-status: not released
+status: v1.8.0
 method: notification
 type:
   name: autoware_adapi_v1_msgs/msg/GearCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/hazard_lights.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/hazard_lights.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/remote/command/hazard_lights
-status: not released
+status: v1.8.0
 method: notification
 type:
   name: autoware_adapi_v1_msgs/msg/HazardLightsCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/pedals.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/pedals.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/remote/command/pedals
-status: not released
+status: v1.8.0
 method: realtime stream
 type:
   name: autoware_adapi_v1_msgs/msg/PedalsCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/steering.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/steering.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/remote/command/steering
-status: not released
+status: v1.8.0
 method: realtime stream
 type:
   name: autoware_adapi_v1_msgs/msg/SteeringCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/turn_indicators.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/turn_indicators.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/remote/command/turn_indicators
-status: not released
+status: v1.8.0
 method: notification
 type:
   name: autoware_adapi_v1_msgs/msg/TurnIndicatorsCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/velocity.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/command/velocity.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/remote/command/velocity
-status: not released
+status: v1.8.0
 method: realtime stream
 type:
   name: autoware_adapi_v1_msgs/msg/VelocityCommand

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/control_mode/list.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/control_mode/list.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/remote/control_mode/list
-status: not released
+status: v1.8.0
 method: function call
 type:
   name: autoware_adapi_v1_msgs/srv/ListManualControlMode

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/control_mode/select.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/control_mode/select.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/remote/control_mode/select
-status: not released
+status: v1.8.0
 method: function call
 type:
   name: autoware_adapi_v1_msgs/srv/SelectManualControlMode

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/control_mode/status.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/control_mode/status.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/remote/control_mode/status
-status: not released
+status: v1.8.0
 method: notification
 type:
   name: autoware_adapi_v1_msgs/msg/ManualControlModeStatus

--- a/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/operator/heartbeat.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/manual/remote/operator/heartbeat.md
@@ -1,6 +1,6 @@
 ---
 title: /api/manual/remote/operator/heartbeat
-status: not released
+status: v1.8.0
 method: realtime stream
 type:
   name: autoware_adapi_v1_msgs/msg/ManualOperatorHeartbeat

--- a/docs/design/autoware-interfaces/ad-api/list/index.md
+++ b/docs/design/autoware-interfaces/ad-api/list/index.md
@@ -7,28 +7,28 @@
 | [/api/interface/version](./api/interface/version.md)                                             | v1.0.0       | function call   |
 | [/api/localization/initialization_state](./api/localization/initialization_state.md)             | v1.0.0       | notification    |
 | [/api/localization/initialize](./api/localization/initialize.md)                                 | v1.0.0       | function call   |
-| [/api/manual/local/command/acceleration](./api/manual/local/command/acceleration.md)             | not released | realtime stream |
-| [/api/manual/local/command/gear](./api/manual/local/command/gear.md)                             | not released | notification    |
-| [/api/manual/local/command/hazard_lights](./api/manual/local/command/hazard_lights.md)           | not released | notification    |
-| [/api/manual/local/command/pedals](./api/manual/local/command/pedals.md)                         | not released | realtime stream |
-| [/api/manual/local/command/steering](./api/manual/local/command/steering.md)                     | not released | realtime stream |
-| [/api/manual/local/command/turn_indicators](./api/manual/local/command/turn_indicators.md)       | not released | notification    |
-| [/api/manual/local/command/velocity](./api/manual/local/command/velocity.md)                     | not released | realtime stream |
-| [/api/manual/local/control_mode/list](./api/manual/local/control_mode/list.md)                   | not released | function call   |
-| [/api/manual/local/control_mode/select](./api/manual/local/control_mode/select.md)               | not released | function call   |
-| [/api/manual/local/control_mode/status](./api/manual/local/control_mode/status.md)               | not released | notification    |
-| [/api/manual/local/operator/heartbeat](./api/manual/local/operator/heartbeat.md)                 | not released | realtime stream |
-| [/api/manual/remote/command/acceleration](./api/manual/remote/command/acceleration.md)           | not released | realtime stream |
-| [/api/manual/remote/command/gear](./api/manual/remote/command/gear.md)                           | not released | notification    |
-| [/api/manual/remote/command/hazard_lights](./api/manual/remote/command/hazard_lights.md)         | not released | notification    |
-| [/api/manual/remote/command/pedals](./api/manual/remote/command/pedals.md)                       | not released | realtime stream |
-| [/api/manual/remote/command/steering](./api/manual/remote/command/steering.md)                   | not released | realtime stream |
-| [/api/manual/remote/command/turn_indicators](./api/manual/remote/command/turn_indicators.md)     | not released | notification    |
-| [/api/manual/remote/command/velocity](./api/manual/remote/command/velocity.md)                   | not released | realtime stream |
-| [/api/manual/remote/control_mode/list](./api/manual/remote/control_mode/list.md)                 | not released | function call   |
-| [/api/manual/remote/control_mode/select](./api/manual/remote/control_mode/select.md)             | not released | function call   |
-| [/api/manual/remote/control_mode/status](./api/manual/remote/control_mode/status.md)             | not released | notification    |
-| [/api/manual/remote/operator/heartbeat](./api/manual/remote/operator/heartbeat.md)               | not released | realtime stream |
+| [/api/manual/local/command/acceleration](./api/manual/local/command/acceleration.md)             | v1.8.0       | realtime stream |
+| [/api/manual/local/command/gear](./api/manual/local/command/gear.md)                             | v1.8.0       | notification    |
+| [/api/manual/local/command/hazard_lights](./api/manual/local/command/hazard_lights.md)           | v1.8.0       | notification    |
+| [/api/manual/local/command/pedals](./api/manual/local/command/pedals.md)                         | v1.8.0       | realtime stream |
+| [/api/manual/local/command/steering](./api/manual/local/command/steering.md)                     | v1.8.0       | realtime stream |
+| [/api/manual/local/command/turn_indicators](./api/manual/local/command/turn_indicators.md)       | v1.8.0       | notification    |
+| [/api/manual/local/command/velocity](./api/manual/local/command/velocity.md)                     | v1.8.0       | realtime stream |
+| [/api/manual/local/control_mode/list](./api/manual/local/control_mode/list.md)                   | v1.8.0       | function call   |
+| [/api/manual/local/control_mode/select](./api/manual/local/control_mode/select.md)               | v1.8.0       | function call   |
+| [/api/manual/local/control_mode/status](./api/manual/local/control_mode/status.md)               | v1.8.0       | notification    |
+| [/api/manual/local/operator/heartbeat](./api/manual/local/operator/heartbeat.md)                 | v1.8.0       | realtime stream |
+| [/api/manual/remote/command/acceleration](./api/manual/remote/command/acceleration.md)           | v1.8.0       | realtime stream |
+| [/api/manual/remote/command/gear](./api/manual/remote/command/gear.md)                           | v1.8.0       | notification    |
+| [/api/manual/remote/command/hazard_lights](./api/manual/remote/command/hazard_lights.md)         | v1.8.0       | notification    |
+| [/api/manual/remote/command/pedals](./api/manual/remote/command/pedals.md)                       | v1.8.0       | realtime stream |
+| [/api/manual/remote/command/steering](./api/manual/remote/command/steering.md)                   | v1.8.0       | realtime stream |
+| [/api/manual/remote/command/turn_indicators](./api/manual/remote/command/turn_indicators.md)     | v1.8.0       | notification    |
+| [/api/manual/remote/command/velocity](./api/manual/remote/command/velocity.md)                   | v1.8.0       | realtime stream |
+| [/api/manual/remote/control_mode/list](./api/manual/remote/control_mode/list.md)                 | v1.8.0       | function call   |
+| [/api/manual/remote/control_mode/select](./api/manual/remote/control_mode/select.md)             | v1.8.0       | function call   |
+| [/api/manual/remote/control_mode/status](./api/manual/remote/control_mode/status.md)             | v1.8.0       | notification    |
+| [/api/manual/remote/operator/heartbeat](./api/manual/remote/operator/heartbeat.md)               | v1.8.0       | realtime stream |
 | [/api/motion/accept_start](./api/motion/accept_start.md)                                         | not released | function call   |
 | [/api/motion/state](./api/motion/state.md)                                                       | not released | notification    |
 | [/api/operation_mode/change_to_autonomous](./api/operation_mode/change_to_autonomous.md)         | v1.0.0       | function call   |

--- a/docs/design/autoware-interfaces/ad-api/release.md
+++ b/docs/design/autoware-interfaces/ad-api/release.md
@@ -1,5 +1,9 @@
 # Release notes
 
+## v1.8.0
+
+- [New] Add [manual control API](./features/manual-control.md)
+
 ## v1.7.0
 
 - [Chore] Change the messages for the prototype implementation.


### PR DESCRIPTION
## Description

Update AD API documents for v1.8.0 release. See [release note page](https://github.com/isamu-takagi/autoware-documentation/blob/feat/adapi-v1.8.0/docs/design/autoware-interfaces/ad-api/release.md) for details.

## How was this PR tested?

None

## Notes for reviewers

None.

## Effects on system behavior

None.
