### PR TITLE
docs: fix architecture_type for scenario_simulator_v2 (20250130)

### DIFF
--- a/docs/tutorials/scenario-simulation/planning-simulation/random-test-simulation.md
+++ b/docs/tutorials/scenario-simulation/planning-simulation/random-test-simulation.md
@@ -18,7 +18,7 @@
 
    ```bash
    ros2 launch random_test_runner random_test.launch.py \
-     architecture_type:=awf/universe/20240605 \
+     architecture_type:=awf/universe/20250130 \
      sensor_model:=sample_sensor_kit \
      vehicle_model:=sample_vehicle
    ```

--- a/docs/tutorials/scenario-simulation/planning-simulation/scenario-test-simulation.md
+++ b/docs/tutorials/scenario-simulation/planning-simulation/scenario-test-simulation.md
@@ -18,7 +18,7 @@
 
    ```bash
    ros2 launch scenario_test_runner scenario_test_runner.launch.py \
-     architecture_type:=awf/universe/20240605 \
+     architecture_type:=awf/universe/20250130 \
      record:=false \
      scenario:='$(find-pkg-share scenario_test_runner)/scenario/sample.yaml' \
      sensor_model:=sample_sensor_kit \


### PR DESCRIPTION
## Description

When using `scenario_simulator_v2`, for the latest Autoware, it is preffeered to specify `awf/universe/20250130` as the launch argument `architecture_type`.

The `architecture_type` parameter of `scenario_simulator_v2` is mainly used:
- to switch traffic light messages (`>awf/universe/20240605`), 
- to support message type `autoware_internal_planning_msgs::msg::PathWithLaneId` (`>awf/universe/20250130`).

For more details, see https://github.com/tier4/scenario_simulator_v2/pull/1518.

## Notes for reviewers

None.

## Effects on system behavior

None.
