### PR TITLE
feat(ad-api): rename control command api

### DIFF
--- a/docs/design/autoware-interfaces/ad-api/features/control.md
+++ b/docs/design/autoware-interfaces/ad-api/features/control.md
@@ -1,0 +1,13 @@
+# Control
+
+## Related API
+
+- {{ link_ad_api('/api/control/command/acceleration') }}
+- {{ link_ad_api('/api/control/command/pedals') }}
+- {{ link_ad_api('/api/control/command/steering') }}
+- {{ link_ad_api('/api/control/command/velocity') }}
+
+## Commands
+
+The control commands are target values that Autoware is sending to the vehicle. Note that unlike vehicle status, this does not represent the actual vehicle status.
+Some commands may not be supported depending on the vehicle control method.

--- a/docs/design/autoware-interfaces/ad-api/features/vehicle-status.md
+++ b/docs/design/autoware-interfaces/ad-api/features/vehicle-status.md
@@ -7,10 +7,6 @@
 - {{ link_ad_api('/api/vehicle/metrics') }}
 - {{ link_ad_api('/api/vehicle/dimensions') }}
 - {{ link_ad_api('/api/vehicle/specs') }}
-- {{ link_ad_api('/api/vehicle/command/acceleration') }}
-- {{ link_ad_api('/api/vehicle/command/pedals') }}
-- {{ link_ad_api('/api/vehicle/command/steering') }}
-- {{ link_ad_api('/api/vehicle/command/velocity') }}
 
 ## Kinematics
 
@@ -30,8 +26,3 @@ The remaining energy can be used for vehicle dispatch scheduling.
 ## Dimensions
 
 The vehicle dimensions are used to know the actual distance between the vehicle and objects because the vehicle position in kinematics is the coordinates of the base link. This is necessary for visualization when supporting vehicles remotely.
-
-## Commands
-
-The vehicle commands are target values that Autoware is sending to the vehicle. Note that unlike vehicle status, this does not represent the actual vehicle status.
-Some commands may not be supported depending on the vehicle control method.

--- a/docs/design/autoware-interfaces/ad-api/list/api/control/command/acceleration.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/control/command/acceleration.md
@@ -1,5 +1,5 @@
 ---
-title: /api/vehicle/command/acceleration
+title: /api/control/command/acceleration
 status: not released
 method: realtime stream
 type:

--- a/docs/design/autoware-interfaces/ad-api/list/api/control/command/pedals.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/control/command/pedals.md
@@ -1,5 +1,5 @@
 ---
-title: /api/vehicle/command/pedals
+title: /api/control/command/pedals
 status: not released
 method: realtime stream
 type:

--- a/docs/design/autoware-interfaces/ad-api/list/api/control/command/steering.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/control/command/steering.md
@@ -1,17 +1,17 @@
 ---
-title: /api/vehicle/command/velocity
+title: /api/control/command/steering
 status: not released
 method: realtime stream
 type:
-  name: autoware_adapi_v1_msgs/msg/VelocityCommand
+  name: autoware_adapi_v1_msgs/msg/SteeringCommand
   msg:
     - name: stamp
       text: Timestamp when this message was sent.
-    - name: velocity
-      text: Target velocity [m/s].
+    - name: steering_tire_angle
+      text: Target steering tire angle [rad].
 ---
 
 {% extends 'design/autoware-interfaces/templates/autoware-interface.jinja2' %}
 {% block description %}
-This is the target velocity that Autoware is sending to the vehicle.
+This is the target steering that Autoware is sending to the vehicle.
 {% endblock %}

--- a/docs/design/autoware-interfaces/ad-api/list/api/control/command/velocity.md
+++ b/docs/design/autoware-interfaces/ad-api/list/api/control/command/velocity.md
@@ -1,17 +1,17 @@
 ---
-title: /api/vehicle/command/steering
+title: /api/control/command/velocity
 status: not released
 method: realtime stream
 type:
-  name: autoware_adapi_v1_msgs/msg/SteeringCommand
+  name: autoware_adapi_v1_msgs/msg/VelocityCommand
   msg:
     - name: stamp
       text: Timestamp when this message was sent.
-    - name: steering_tire_angle
-      text: Target steering tire angle [rad].
+    - name: velocity
+      text: Target velocity [m/s].
 ---
 
 {% extends 'design/autoware-interfaces/templates/autoware-interface.jinja2' %}
 {% block description %}
-This is the target steering that Autoware is sending to the vehicle.
+This is the target velocity that Autoware is sending to the vehicle.
 {% endblock %}

--- a/docs/design/autoware-interfaces/ad-api/list/index.md
+++ b/docs/design/autoware-interfaces/ad-api/list/index.md
@@ -2,6 +2,10 @@
 
 | API                                                                                              | Release      | Method          |
 | ------------------------------------------------------------------------------------------------ | ------------ | --------------- |
+| [/api/control/command/acceleration](./api/control/command/acceleration.md)                       | not released | realtime stream |
+| [/api/control/command/pedals](./api/control/command/pedals.md)                                   | not released | realtime stream |
+| [/api/control/command/steering](./api/control/command/steering.md)                               | not released | realtime stream |
+| [/api/control/command/velocity](./api/control/command/velocity.md)                               | not released | realtime stream |
 | [/api/fail_safe/mrm_description](./api/fail_safe/mrm_description.md)                             | not released | function call   |
 | [/api/fail_safe/mrm_request/list](./api/fail_safe/mrm_request/list.md)                           | not released | notification    |
 | [/api/fail_safe/mrm_request/send](./api/fail_safe/mrm_request/send.md)                           | not released | function call   |
@@ -58,10 +62,6 @@
 | [/api/system/diagnostics/status](./api/system/diagnostics/status.md)                             | v1.3.0       | realtime stream |
 | [/api/system/diagnostics/struct](./api/system/diagnostics/struct.md)                             | v1.3.0       | notification    |
 | [/api/system/heartbeat](./api/system/heartbeat.md)                                               | v1.3.0       | realtime stream |
-| [/api/vehicle/command/acceleration](./api/vehicle/command/acceleration.md)                       | not released | realtime stream |
-| [/api/vehicle/command/pedals](./api/vehicle/command/pedals.md)                                   | not released | realtime stream |
-| [/api/vehicle/command/steering](./api/vehicle/command/steering.md)                               | not released | realtime stream |
-| [/api/vehicle/command/velocity](./api/vehicle/command/velocity.md)                               | not released | realtime stream |
 | [/api/vehicle/dimensions](./api/vehicle/dimensions.md)                                           | v1.1.0       | function call   |
 | [/api/vehicle/doors/command](./api/vehicle/doors/command.md)                                     | v1.2.0       | function call   |
 | [/api/vehicle/doors/layout](./api/vehicle/doors/layout.md)                                       | v1.2.0       | function call   |


### PR DESCRIPTION
## Description

The name "vehicle command" is confusing with the actual value of the vehicle.
This API is a target value, so rename it to "control command" before release.

## How was this PR tested?

None

## Notes for reviewers

None.

## Effects on system behavior

None.
