### PR TITLE
feat: update Autoware Concepts page

### DIFF
--- a/docs/design/autoware-concepts/.pages
+++ b/docs/design/autoware-concepts/.pages
@@ -1,3 +1,2 @@
 nav:
   - index.md
-  - difference-from-ai-and-auto.md

--- a/docs/design/autoware-concepts/index.md
+++ b/docs/design/autoware-concepts/index.md
@@ -3,20 +3,25 @@
 The concept of Autoware revolves around providing an open and flexible platform to accelerate the development and deployment of autonomous driving systems. Below is an extended explanation of its key principles.
 
 ## 1. Open Source Software
+
 Autoware is an open source software framework for autonomous driving, licensed under the Apache 2.0 license. This permissive licensing model allows users to freely use, modify, and distribute the software, even for commercial purposes, while ensuring proper attribution. This provides the following benefits to the users and developers:
- - **Transparency & Validation:** Open access to the source code allows researchers, developers, and industry experts to inspect, validate, and improve the software, ensuring robustness and reliability.
- - **Collaboration & Innovation:** A shared development model encourages contributions from a global community, accelerating advancements in autonomous technology.
- - **Interoperability & Standardization:** Autoware adheres to common standards and widely adopted environments, ensuring seamless integration with diverse platforms, sensors, and vehicle architectures.
- - **Cost & Accessibility:** By eliminating proprietary software costs, Autoware lowers the barriers to entry for startups, researchers, and commercial developers, enabling broader adoption and experimentation.
+
+- **Transparency & Validation:** Open access to the source code allows researchers, developers, and industry experts to inspect, validate, and improve the software, ensuring robustness and reliability.
+- **Collaboration & Innovation:** A shared development model encourages contributions from a global community, accelerating advancements in autonomous technology.
+- **Interoperability & Standardization:** Autoware adheres to common standards and widely adopted environments, ensuring seamless integration with diverse platforms, sensors, and vehicle architectures.
+- **Cost & Accessibility:** By eliminating proprietary software costs, Autoware lowers the barriers to entry for startups, researchers, and commercial developers, enabling broader adoption and experimentation.
 
 ## 2. Comprehensive Functionality
+
 Autoware offers a complete suite of capabilities for autonomous driving system development including:
+
 - **Key Components for AD Systems:** Autoware provides various algorithms for localization, obstacle detection, path planning, and vehicle control for users to choose depending on their needs.
 - **Hardware Integration:** Autoware provides reference implementation and instructions for integrating with different sensors and vehicles.
 - **Simulation Support:** Autoware works with simulation platforms to validate algorithms and scenarios before real-world deployment.
 - **Tools:** Provides useful tools for development including sensor calibration, mapping, data creation, diagnostic, and scenario tests.
 
 ## 3. Microautonomy Architecture
+
 Autoware is designed with a modular and flexible architecture, enabling seamless adaptation to a wide range of requirements and use cases. Its well-defined interface design facilitates efficient inter-component communication, allowing for the smooth integration of new features and functionalities.
 
 For instance, users can replace the default object detection module with a custom neural network tailored for specific tasks, such as identifying construction cones in a work zone. This ability to swap or enhance individual modules without disrupting the rest of the system underscores Autoware’s flexibility and robustness.
@@ -28,6 +33,7 @@ This architecture is made possible through collaboration with AWF partners, who 
 ![Overview](../autoware-architecture/image/autoware-architecture-overview.drawio.svg)
 
 ## 4. Core & Universe Package Management
+
 Autoware consists of packages managed by the Autoware Foundation as well as open-source contributions outside the foundation.
 
 The packages maintained by the Autoware Foundation (AWF) are referred to as **Autoware Core**, and maintained under the AWF GitHub organization. These packages are developed and released according to quality standards set by AWF, which include unit tests, integration tests, and real-world testing. The users are expected to use the Core packages as the base platform for their autonomous driving systems.
@@ -35,7 +41,6 @@ The packages maintained by the Autoware Foundation (AWF) are referred to as **Au
 In contrast, **Autoware Universe** is a collection of OSS packages that are independently developed and maintained by external individuals, companies, and research institutions. These packages are owned and managed by their original authors, who follow their own criteria for code quality and functionality. Authors have the option to either directly merge their contributions into the Autoware Universe repository hosted by the Autoware Foundation or register their own repositories as part of the Universe repository list. Autoware Universe packages may be ported to Autoware Core if their functionality and maturity are recognized by the Autoware Foundation.
 
 With this two-tier package management, the Autoware Foundation ensures a quality-assured base platform by Autoware Core, while also fostering a collaborative ecosystem where third-party developers can easily share their contributions with the community under Autoware Universe.
-
 
 <!--
 We comment out the following section for now, as it is not relevant to the new page outline.

--- a/docs/design/autoware-concepts/index.md
+++ b/docs/design/autoware-concepts/index.md
@@ -1,24 +1,45 @@
 # Autoware concepts
 
-Autoware is the world’s first open-source software for autonomous driving systems. Autoware provides value for both technology developers and service operators. The technology developers of autonomous driving systems can create new components based on Autoware. The service operators of autonomous driving systems, on the other hand, can select appropriate technology components with Autoware. This is enabled by the microautonomy architecture that modularizes its software stack into the core and universe subsystems (modules).
+The concept of Autoware revolves around providing an open and flexible platform to accelerate the development and deployment of autonomous driving systems. Below is an extended explanation of its key principles.
 
-## Microautonomy architecture
+## 1. Open Source Software
+Autoware is an open source software framework for autonomous driving, licensed under the Apache 2.0 license. This permissive licensing model allows users to freely use, modify, and distribute the software, even for commercial purposes, while ensuring proper attribution. This provides the following benefits to the users and developers:
+ - **Transparency & Validation:** Open access to the source code allows researchers, developers, and industry experts to inspect, validate, and improve the software, ensuring robustness and reliability.
+ - **Collaboration & Innovation:** A shared development model encourages contributions from a global community, accelerating advancements in autonomous technology.
+ - **Interoperability & Standardization:** Autoware adheres to common standards and widely adopted environments, ensuring seamless integration with diverse platforms, sensors, and vehicle architectures.
+ - **Cost & Accessibility:** By eliminating proprietary software costs, Autoware lowers the barriers to entry for startups, researchers, and commercial developers, enabling broader adoption and experimentation.
 
-Autoware uses a [pipeline architecture](http://www.cs.sjsu.edu/~pearce/modules/patterns/distArch/pipeline.htm) to enable the development of autonomous driving systems. The pipeline architecture used in Autoware consists of components similar to [three-layer-architecture](http://www.flownet.com/gat/papers/tla.pdf). And they run in parallel. There are 2 main modules: the Core and the Universe. The components in these modules are designed to be extensible and reusable. And we call it microautonomy architecture.
+## 2. Comprehensive Functionality
+Autoware offers a complete suite of capabilities for autonomous driving system development including:
+- **Key Components for AD Systems:** Autoware provides various algorithms for localization, obstacle detection, path planning, and vehicle control for users to choose depending on their needs.
+- **Hardware Integration:** Autoware provides reference implementation and instructions for integrating with different sensors and vehicles.
+- **Simulation Support:** Autoware works with simulation platforms to validate algorithms and scenarios before real-world deployment.
+- **Tools:** Provides useful tools for development including sensor calibration, mapping, data creation, diagnostic, and scenario tests.
 
-![core-and-universe.svg](core-and-universe.svg)
+## 3. Microautonomy Architecture
+Autoware is designed with a modular and flexible architecture, enabling seamless adaptation to a wide range of requirements and use cases. Its well-defined interface design facilitates efficient inter-component communication, allowing for the smooth integration of new features and functionalities.
 
-### The Core module
+For instance, users can replace the default object detection module with a custom neural network tailored for specific tasks, such as identifying construction cones in a work zone. This ability to swap or enhance individual modules without disrupting the rest of the system underscores Autoware’s flexibility and robustness.
 
-The Core module contains basic runtimes and technology components that satisfy the basic functionality and capability of sensing, computing, and actuation required for autonomous driving systems. AWF develops and maintains the Core module with their architects and leading members through their working groups. Anyone can contribute to the Core but the PR(Pull Request) acceptance criteria is more strict compared to the Universe.
+At the core of the microautonomy architecture is its interface design, which is categorized into internal and external interfaces. Internal [**Component Interfaces**](../autoware-interfaces/components/) connect components across different modules within Autoware, facilitating coordinated behavior. External interfaces called [**Autonomous Driving (AD) API**](../autoware-interfaces/ad-api/) expose Autoware’s capabilities to external applications, such as infotainment systems and cloud services.
 
-### The Universe module
+This architecture is made possible through collaboration with AWF partners, who both contribute to and benefit from the clearly defined and standardized interfaces.
 
-The Universe modules are extensions to the Core module that can be provided by the technology developers to enhance the functionality and capability of sensing, computing, and actuation. AWF provides the base Universe module to extend from. A key feature of the microautonomy architecture is that the Universe modules can be contributed to by any organization and individual. That is, you can even create your Universe and make it available for the Autoware community and ecosystem. AWF is responsible for quality control of the Universe modules through their development process. As a result, there are multiple types of the Universe modules - some are verified and validated by AWF and others are not. It is up to the users of Autoware which Universe modules are selected and integrated to build their end applications.
+![Overview](../autoware-architecture/image/autoware-architecture-overview.drawio.svg)
 
-## Interface design
+## 4. Core & Universe Package Management
+Autoware consists of packages managed by the Autoware Foundation as well as open-source contributions outside the foundation.
 
-The interface design is the most essential piece of the microautonomy architecture, which is classified into internal and external interfaces. The component interface is designed for the components in a Universe module to communicate with those in other modules, including the Core module, within Autoware internally. The AD(Autonomous Driving) API, on the other hand, is designed for the applications of Autoware to access the technology components in the Core and Universe modules of Autoware externally. Designing solid interfaces, the microautonomy architecture is made possible with AWF's partners, and at the same time is made feasible for the partners.
+The packages maintained by the Autoware Foundation (AWF) are referred to as **Autoware Core**, and maintained under the AWF GitHub organization. These packages are developed and released according to quality standards set by AWF, which include unit tests, integration tests, and real-world testing. The users are expected to use the Core packages as the base platform for their autonomous driving systems.
+
+In contrast, **Autoware Universe** is a collection of OSS packages that are independently developed and maintained by external individuals, companies, and research institutions. These packages are owned and managed by their original authors, who follow their own criteria for code quality and functionality. Authors have the option to either directly merge their contributions into the Autoware Universe repository hosted by the Autoware Foundation or register their own repositories as part of the Universe repository list. Autoware Universe packages may be ported to Autoware Core if their functionality and maturity are recognized by the Autoware Foundation.
+
+With this two-tier package management, the Autoware Foundation ensures a quality-assured base platform by Autoware Core, while also fostering a collaborative ecosystem where third-party developers can easily share their contributions with the community under Autoware Universe.
+
+
+<!--
+We comment out the following section for now, as it is not relevant to the new page outline.
+We can add it back in system design page when we create it.
 
 ## Challenges
 
@@ -33,4 +54,4 @@ Goals:
 - All open-source
 - Use case driven
 - Real-time (predictable) framework with overrun handling
-- Code quality
+- Code quality -->


### PR DESCRIPTION
## Description
This updates the Autoware Concepts page to describe Autoware's design concepts.
I also removed the difference-from-ai-and-auto.md page from index from concepts page now. It's quite old page and is not really explaining about the concepts so much. I'm planning to create a page for "past releases". and I can re-add the explanation about Autoware AI and Autoware Auto under that section.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
