### PR TITLE
fix(deploy-docs): revert to ubuntu-22.04

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -11,7 +11,12 @@ on:
       - "**/*.svg"
       - "**/*.png"
       - "**/*.jpg"
-  pull_request_target:
+#  pull_request_target:
+#    types:
+#      - opened
+#      - synchronize
+#      - labeled
+  pull_request:
     types:
       - opened
       - synchronize
@@ -36,7 +41,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Deploy docs
-        uses: autowarefoundation/autoware-github-actions/deploy-docs@fix-deploy-docs
+        uses: autowarefoundation/autoware-github-actions/deploy-docs@test-evshary-solution
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: ${{ github.event_name != 'pull_request_target' && github.ref_name == github.event.repository.default_branch }}

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -36,7 +36,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Deploy docs
-        uses: evshary/autoware-github-actions/deploy-docs@main
+        uses: autowarefoundation/autoware-github-actions/deploy-docs@test-evshary-solution
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: ${{ github.event_name != 'pull_request_target' && github.ref_name == github.event.repository.default_branch }}

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -36,7 +36,8 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Deploy docs
-        uses: autowarefoundation/autoware-github-actions/deploy-docs@test-evshary-solution
+        uses: autowarefoundation/autoware-github-actions/deploy-docs@fix-deploy-docs
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: ${{ github.event_name != 'pull_request_target' && github.ref_name == github.event.repository.default_branch }}
+          debug-mode: true

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -11,11 +11,11 @@ on:
       - "**/*.svg"
       - "**/*.png"
       - "**/*.jpg"
-#  pull_request_target:
-#    types:
-#      - opened
-#      - synchronize
-#      - labeled
+  #  pull_request_target:
+  #    types:
+  #      - opened
+  #      - synchronize
+  #      - labeled
   pull_request:
     types:
       - opened

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -36,7 +36,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Deploy docs
-        uses: autowarefoundation/autoware-github-actions/deploy-docs@v1
+        uses: evshary/autoware-github-actions/deploy-docs@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: ${{ github.event_name != 'pull_request_target' && github.ref_name == github.event.repository.default_branch }}


### PR DESCRIPTION
## Description

`deploy-docs` started to fail between 2025 September 10th and 18th.

<img width="937" height="731" alt="image" src="https://github.com/user-attachments/assets/d12c72b1-d1d1-4b7e-ac01-7beb20b5a048" />

https://github.com/autowarefoundation/autoware-documentation/actions/runs/17832331419/job/50700391338#step:3:507

> ```
> error: 'type' object is not subscriptable
> Error: Process completed with exit code 1.
> ```

`mike deploy (main or something else)` command is failing on ubuntu 24.04.
I confirmed in a clean custom `ubuntu 24.04` image and got the same error. But in Ubuntu 22.04 it worked on my host machine.

So hopefully this will fix it for the time being.

## How was this PR tested?

https://github.com/autowarefoundation/autoware-documentation/actions/runs/17856310057/job/50776066687#step:3:507

Well it failed with Ubuntu 22.04 as well.

This needs more debugging.

## Notes for reviewers

None.

## Effects on system behavior

None.
