### PR TITLE
ci(deploy-docs): use require-label to fail if skipped

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -19,13 +19,13 @@ on:
   workflow_dispatch:
 
 jobs:
-  prevent-no-label-execution:
-    uses: autowarefoundation/autoware-github-actions/.github/workflows/prevent-no-label-execution.yaml@v1
+  require-label:
+    uses: autowarefoundation/autoware-github-actions/.github/workflows/require-label.yaml@v1
     with:
       label: tag:deploy-docs
 
   deploy-docs:
-    needs: prevent-no-label-execution
+    needs: require-label
     if: ${{ needs.prevent-no-label-execution.outputs.run == 'true' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

Issue: if this workflow is skipped due to lack of the label, it counts as successful.

Example:

<img width="733" height="159" alt="image" src="https://github.com/user-attachments/assets/075ef5d4-d640-4f8e-9c19-a8f9aa452b9d" />

This PR makes it use `require-label.yaml` instead:
https://github.com/autowarefoundation/autoware-github-actions/blob/main/.github/workflows/require-label.yaml



## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
