### PR TITLE
docs: add VAD CARLA tutorial entry

### DIFF
--- a/docs/demos/digital-twin-demos/carla-tutorial.md
+++ b/docs/demos/digital-twin-demos/carla-tutorial.md
@@ -14,6 +14,28 @@ It is integrated in autoware_universe and actively maintained to stay compatible
 
 - Package Link and Tutorial: [autoware_carla_interface](https://github.com/autowarefoundation/autoware_universe/tree/main/simulator/autoware_carla_interface).
 
+### autoware_tensorrt_vad (end-to-end planning)
+
+TensorRT-optimized Vectorized Autonomous Driving ([VAD](https://github.com/hustvl/VAD)) node that replaces the traditional perception/localization/planning stack with a single end-to-end model trained on CARLA ([Bench2Drive](https://github.com/Thinklab-SJTU/Bench2Drive)). Ships with a CARLA-focused launch file and integrates with `autoware_launch` through `e2e_simulator.launch.xml`.
+
+- Project Link: [autoware_tensorrt_vad](https://github.com/autowarefoundation/autoware/tree/main/src/universe/autoware_universe/planning/autoware_tensorrt_vad) (README includes parameters, topics, and model details)
+- Usage (CARLA E2E mode):
+  1. Build the package and deps: `colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to autoware_tensorrt_vad`.
+  2. Prepare CARLA following `autoware_carla_interface` (use `carla_sensor_kit` so camera topics match the VAD training order: FRONT, BACK, FRONT_LEFT, BACK_LEFT, FRONT_RIGHT, BACK_RIGHT).
+  3. Ensure VAD models are downloaded (default to `~/autoware_data/vad` via the Autoware setup script).
+  4. Start CARLA server (example headless/GPU-friendly): `./CarlaUE4.sh -prefernvidia -quality-level=Low -RenderOffScreen`.
+  5. Launch Autoware in E2E mode:
+
+     ```bash
+     ros2 launch autoware_launch e2e_simulator.launch.xml \
+       map_path:=$HOME/autoware_map/Town01 \
+       vehicle_model:=sample_vehicle \
+       sensor_model:=carla_sensor_kit \
+       simulator_type:=carla \
+       use_e2e_planning:=true \
+       e2e_planning_type:=vad
+     ```
+
 ### carla_autoware_bridge
 
 An addition package to `carla_ros_bridge` to connect CARLA simulator to Autoware Universe software.


### PR DESCRIPTION
  ## Description
  - Add autoware_tensorrt_vad entry to the CARLA Simulation tutorial.
  
  ## How was this PR tested?
  - Not tested (documentation-only change).

  ## Notes for reviewers
  - None.

  ## Effects on system behavior
  - None.