### PR TITLE
chore(.gitignore): add /site/* for mike deploy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # pre-commit
 node_modules/
+
+# mike deploy generates this
+/site/*


### PR DESCRIPTION
## Description

Makes it less annoying to test in local with `mike deploy`

## How was this PR tested?

- Tested along with https://github.com/autowarefoundation/autoware-documentation/pull/702

No side effects when deploying since deployment is in another branch anyways.

## Notes for reviewers

None.

## Effects on system behavior

None.
