### PR TITLE
build: use fontawesome-in-markdown

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -41,6 +41,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: false
+          mkdocs-requirements-txt: mkdocs-requirements.txt
 
   deploy-docs-push:
     if: ${{ github.event_name == 'push' }}
@@ -56,6 +57,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: ${{ github.ref_name == github.event.repository.default_branch }}
+          mkdocs-requirements-txt: mkdocs-requirements.txt
 
   deploy-docs-workflow-dispatch:
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -71,3 +73,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           latest: false
+          mkdocs-requirements-txt: mkdocs-requirements.txt

--- a/mkdocs-requirements.txt
+++ b/mkdocs-requirements.txt
@@ -1,0 +1,17 @@
+fontawesome-in-markdown
+markdown
+mdx_truly_sane_lists
+mkdocs
+mkdocs-awesome-pages-plugin==2.9.1
+mkdocs-exclude
+mkdocs-macros-plugin
+mkdocs-material
+mkdocs-same-dir
+mkdocs-static-i18n
+mkdocs-video
+mike
+pathspec
+plantuml-markdown==3.10.4
+pymdown-extensions
+python-markdown-math
+tabulate

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -68,7 +68,7 @@ markdown_extensions:
   - attr_list
   - codehilite:
       guess_lang: false
-  - fontawesome_markdown
+  - fontawesome_in_markdown
   - footnotes
   - md_in_html
   - mdx_math


### PR DESCRIPTION
## Description

- Related sad story: https://github.com/bmcorser/fontawesome-markdown/pull/20#issuecomment-3580789197

This PR uses the self contained mkdocs-requirements.txt instead of the default https://github.com/autowarefoundation/autoware-github-actions/blob/75b0d400b72573057c2b517314379235b55f8124/deploy-docs/mkdocs-requirements.txt because this way it is a non-breaking change.

## How was this PR tested?

- https://github.com/autowarefoundation/autoware-documentation/actions/runs/19735509008/job/56546330930

## Notes for reviewers

The required CI is failed ❌ and that is expected. ✅

https://github.com/autowarefoundation/autoware-documentation/blob/30436bed9d493d82d75926a06069cda84b59ab98/.github/workflows/deploy-docs.yaml#L14-L19

The PR uses `pull_request_target:` meaning, the changes made to the file workflow itself will take effect once it is merged.

But I tested it with workflow_dispatch: https://github.com/autowarefoundation/autoware-documentation/actions/runs/19735509008/job/56546330930 and it passes ✅

Once it is reviewed I will override and merge.

## Effects on system behavior

None.
