### PR TITLE
chore(mkdocs-yaml): use material.extensions

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -81,8 +81,8 @@ markdown_extensions:
       generic: true
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight
   - pymdownx.snippets:
       auto_append:


### PR DESCRIPTION
## Description

Fixes:

```
INFO    -  DeprecationWarning: 'materialx.emoji.twemoji' is deprecated.
           Material emoji logic has been officially moved into mkdocs-material
           version 9.4. Please use Material's 'material.extensions.emoji.twemoji'
           instead of 'materialx.emoji.twemoji' in your 'mkdocs.yml' file.

           ```
           markdown_extensions:
             - pymdownx.emoji:
                 emoji_index: !!python/name:material.extensions.emoji.twemoji
                 emoji_generator: !!python/name:material.extensions.emoji.to_svg
           ```

           'mkdocs_material_extensions' is deprecated and will no longer be
           supported moving forward. This is the last release.

             File
           "/home/mfc/miniconda3/envs/deploy_docs_new/lib/python3.10/site-packages/materialx/emoji.py",
           line 118, in twemoji
               return _patch_index(options)
             File
           "/home/mfc/miniconda3/envs/deploy_docs_new/lib/python3.10/site-packages/materialx/emoji.py",
           line 68, in _deprecated_func
               warnings.warn(
```

## How was this PR tested?

- https://github.com/autowarefoundation/autoware-documentation/actions/runs/19735980110/job/56547900262#step:3:423 ✅

## Notes for reviewers

None.

## Effects on system behavior

None.
