### PR TITLE
fix: broken internal links

### DIFF
--- a/docs/design/autoware-concepts/index.md
+++ b/docs/design/autoware-concepts/index.md
@@ -26,7 +26,7 @@ Autoware is designed with a modular and flexible architecture, enabling seamless
 
 For instance, users can replace the default object detection module with a custom neural network tailored for specific tasks, such as identifying construction cones in a work zone. This ability to swap or enhance individual modules without disrupting the rest of the system underscores Autoware’s flexibility and robustness.
 
-At the core of the microautonomy architecture is its interface design, which is categorized into internal and external interfaces. Internal [**Component Interfaces**](../autoware-interfaces/components/) connect components across different modules within Autoware, facilitating coordinated behavior. External interfaces called [**Autonomous Driving (AD) API**](../autoware-interfaces/ad-api/) expose Autoware’s capabilities to external applications, such as infotainment systems and cloud services.
+At the core of the microautonomy architecture is its interface design, which is categorized into internal and external interfaces. Internal [**Component Interfaces**](../autoware-interfaces/components/index.md) connect components across different modules within Autoware, facilitating coordinated behavior. External interfaces called [**Autonomous Driving (AD) API**](../autoware-interfaces/ad-api/index.md) expose Autoware’s capabilities to external applications, such as infotainment systems and cloud services.
 
 This architecture is made possible through collaboration with AWF partners, who both contribute to and benefit from the clearly defined and standardized interfaces.
 

--- a/docs/design/autoware-interfaces/components/planning.md
+++ b/docs/design/autoware-interfaces/components/planning.md
@@ -76,7 +76,7 @@ This page provides specific specifications about the Interface of the Planning C
 
 ## Planning internal interface
 
-This section explains the communication between the different planning modules shown in the [Planning Architecture Design](../../autoware-architecture/planning/index.md#high-level-architecture).
+This section explains the communication between the different planning modules shown in the [Planning Architecture Design](../../autoware-architecture/planning/index.md#high-level-design).
 
 ![planning-internal](images/planning-interface-internal.drawio.svg)
 

--- a/docs/how-to-guides/integrating-autoware/integrating-sensors/integrating-cameras.md
+++ b/docs/how-to-guides/integrating-autoware/integrating-sensors/integrating-cameras.md
@@ -51,7 +51,7 @@ Each interface type requires different components to be implemented or configure
 ### Calibration
 
 Calibration may be required to calculate the camera intrinsic parameters for some use cases, such as 3D to 2D projection (performed during traffic light recognition) and rectification.
-For the calibration procedure, please refer to the documentation [here](/autoware-documentation/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-model/calibrating-sensors/intrinsic-camera-calibration/) for more details.
+For the calibration procedure, please refer to the documentation [here](../../integrating-autoware/creating-vehicle-and-sensor-model/calibrating-sensors/intrinsic-camera-calibration/index.md) for more details.
 
 ### Time synchronization
 

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -131,33 +131,33 @@ Open AD Kit provides different deployment options for Autoware, so that you can 
 
    If there is any build issue, refer to [Troubleshooting](../../support/troubleshooting/index.md#build-issues).
 
-> **To Update the Workspace**
->
-> ```bash
-> cd autoware
-> git pull
-> vcs import src < autoware.repos
->
-> # If you are using nightly repositories, also run the following command:
-> vcs import src < autoware-nightly.repos
->
-> vcs pull src
-> # Make sure all ros-$ROS_DISTRO-* packages are upgraded to their latest version
-> sudo apt update && sudo apt upgrade
-> rosdep update
-> rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
-> ```
->
-> It might be the case that dependencies imported via `vcs import` have been moved/removed.
-> VCStool does not currently handle those cases, so if builds fail after `vcs import`, cleaning
-> and re-importing all dependencies may be necessary:
->
-> ```bash
-> rm -rf src/*
-> vcs import src < autoware.repos
-> # If you are using nightly repositories, import them as well.
-> vcs import src < autoware-nightly.repos
-> ```
+### Update the Workspace
+
+```bash
+cd autoware
+git pull
+vcs import src < autoware.repos
+
+# If you are using nightly repositories, also run the following command:
+vcs import src < autoware-nightly.repos
+
+vcs pull src
+# Make sure all ros-$ROS_DISTRO-* packages are upgraded to their latest version
+sudo apt update && sudo apt upgrade
+rosdep update
+rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO
+```
+
+It might be the case that dependencies imported via `vcs import` have been moved/removed.
+VCStool does not currently handle those cases, so if builds fail after `vcs import`, cleaning
+and re-importing all dependencies may be necessary:
+
+```bash
+rm -rf src/*
+vcs import src < autoware.repos
+# If you are using nightly repositories, import them as well.
+vcs import src < autoware-nightly.repos
+```
 
 ### Using VS Code remote containers for development
 

--- a/docs/support/troubleshooting/index.md
+++ b/docs/support/troubleshooting/index.md
@@ -112,7 +112,7 @@ rm -rf build/ install/ log/
 colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 
-If the error is not resolved, remove `src/` and update your workspace according to installation type ([Docker](../../installation/autoware/docker-installation.md#how-to-update-a-workspace) / [source](../../installation/autoware/source-installation.md#how-to-update-a-workspace)).
+If the error is not resolved, remove `src/` and update your workspace according to installation type ([Docker](../../installation/autoware/docker-installation.md#update-the-workspace) / [source](../../installation/autoware/source-installation.md#how-to-update-a-workspace)).
 
 !!! Warning
 
@@ -192,7 +192,7 @@ If you have any of these symptoms, please the [Performance Troubleshooting](perf
 
 ### Map does not display when running the Planning Simulator
 
-When running the Planning Simulator, the most common reason for the map not being displayed in RViz is because [the map path has not been specified correctly in the launch command](../../tutorials/ad-hoc-simulation/planning-simulation.md#how-to-run-a-planning-simulation). You can confirm if this is the case by searching for `Could not find lanelet map under {path-to-map-dir}/lanelet2_map.osm` errors in the log.
+When running the Planning Simulator, the most common reason for the map not being displayed in RViz is because [the map path has not been specified correctly in the launch command](../../tutorials/ad-hoc-simulation/planning-simulation.md#lane-driving-scenario). You can confirm if this is the case by searching for `Could not find lanelet map under {path-to-map-dir}/lanelet2_map.osm` errors in the log.
 
 Another possible reason is that map loading is taking a long time due to poor DDS performance. For this, please visit the [Performance Troubleshooting](performance-troubleshooting.md) page.
 


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware-documentation/actions/runs/19698007085/job/56427219709#step:3:482

so many broken links, fixed manually.

```
INFO    -  Doc file 'design/autoware-concepts/index.md' contains an unrecognized relative link '../autoware-interfaces/components/', it was left as is. Did you mean '../autoware-interfaces/components/index.md'?
INFO    -  Doc file 'design/autoware-concepts/index.md' contains an unrecognized relative link '../autoware-interfaces/ad-api/', it was left as is. Did you mean '../autoware-interfaces/ad-api/index.md'?
INFO    -  Doc file 'how-to-guides/integrating-autoware/integrating-sensors/integrating-cameras.md' contains an absolute link '/autoware-documentation/how-to-guides/integrating-autoware/creating-vehicle-and-sensor-model/calibrating-sensors/intrinsic-camera-calibration/', it was left as is.
INFO    -  Doc file 'design/autoware-interfaces/components/planning.md' contains a link '../../autoware-architecture/planning/index.md#high-level-architecture', but the doc 'design/autoware-architecture/planning/index.md' does not contain an anchor '#high-level-architecture'.
INFO    -  Doc file 'support/troubleshooting/index.md' contains a link '../../installation/autoware/docker-installation.md#how-to-update-a-workspace', but the doc 'installation/autoware/docker-installation.md' does not contain an anchor '#how-to-update-a-workspace'.
INFO    -  Doc file 'support/troubleshooting/index.md' contains a link '../../tutorials/ad-hoc-simulation/planning-simulation.md#how-to-run-a-planning-simulation', but the doc 'tutorials/ad-hoc-simulation/planning-simulation.md' does not contain an anchor '#how-to-run-a-planning-simulation'.
```

## How was this PR tested?

Deploy docs.

## Notes for reviewers

None.

## Effects on system behavior

None.
