### PR TITLE
feat(mkdocs.yaml): add formatting extensions

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -83,11 +83,16 @@ markdown_extensions:
       format: svg
   - pymdownx.arithmatex:
       generic: true
+  - pymdownx.caret
+  - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.highlight
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.tilde
   - pymdownx.snippets:
       auto_append:
         - includes/abbreviations.md


### PR DESCRIPTION
## Description

- https://squidfunk.github.io/mkdocs-material/reference/formatting/

Adding the extensions listed here.
Very convenient.

---

<img width="678" height="1249" alt="image" src="https://github.com/user-attachments/assets/a46ce8d5-c8e1-47f6-8356-e5dc8785ddd7" />

<img width="699" height="248" alt="image" src="https://github.com/user-attachments/assets/beb65d46-5605-4f05-b322-c6ad237ef5f6" />

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
