### PR TITLE
chore(mkdocs.yaml): bump the fontawesome version

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -46,7 +46,7 @@ extra:
 
 extra_css:
   - assets/css/extra.css
-  - https://use.fontawesome.com/releases/v5.15.4/css/all.css
+  - https://use.fontawesome.com/releases/v7.1.0/css/all.css
 
 extra_javascript:
   - assets/js/mathjax.js


### PR DESCRIPTION
## Description

```
- test1 :fa-coffee:
- test2 :fa-cl-s fa-star:
- test3 :fa-cl-r fa-star:
- test4 :fa-sh-s fa-star:
- test5 :fa fa-coffee:
- test6 :fontawesome-regular-face-laugh-wink:
- test7 :fontawesome-brands-youtube:
```

**Before:**
<img height="200" alt="image" src="https://github.com/user-attachments/assets/63f0e505-ac70-4782-941f-bb83a7edf847" />

**After:**

<img height="200" alt="image" src="https://github.com/user-attachments/assets/53e23cdb-7428-431b-963e-c0903b560cbb" />

### 🔗 Useful links

- https://github.com/stickgrinder/fontawesome-in-markdown
- https://fontawesome.com/versions
- https://fontawesome.com/search?q=star&ic=free-collection

## How was this PR tested?

Locally. The versions are backwards compatible anyways.

## Notes for reviewers

None.

## Effects on system behavior

None.
