### PR TITLE
ci(deploy-docs): pass the secret correctly

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -77,5 +77,5 @@ jobs:
 
   reorder-versions-json:
     uses: ./.github/workflows/reorder-versions.yml
-    with:
+    secrets:
       token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reorder-versions.yaml
+++ b/.github/workflows/reorder-versions.yaml
@@ -2,11 +2,10 @@ name: reorder-versions
 
 on:
   workflow_call:
-    inputs:
+    secrets:
       token:
         description: GitHub token
         required: true
-        type: string
   workflow_dispatch:
 
 jobs:
@@ -91,7 +90,7 @@ jobs:
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:
-          token: ${{ inputs.token }}
+          token: ${{ secrets.token }}
 
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
## Description

- follow up from https://github.com/autowarefoundation/autoware-documentation/pull/718

https://github.com/autowarefoundation/autoware-documentation/actions/runs/19815899794/workflow

```
Invalid workflow file

(Line: 83, Col: 14): Unrecognized named-value: 'secrets'. Located at position 1 within expression: secrets.GITHUB_TOKEN
```

---

https://docs.github.com/en/actions/how-tos/reuse-automations/reuse-workflows#using-inputs-and-secrets-in-a-reusable-workflow

We need to use the `secrets:` instead of `inputs` for secrets. This PR fixes that.

## How was this PR tested?

Since this runs for `pull_request_target` we need to merge before seeing the results.

## Notes for reviewers

None.

## Effects on system behavior

None.
