### PR TITLE
ci(deploy-docs): fix reorder-versions.yaml workflow name

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -76,6 +76,6 @@ jobs:
           mkdocs-requirements-txt: mkdocs-requirements.txt
 
   reorder-versions-json:
-    uses: ./.github/workflows/reorder-versions.yml
+    uses: ./.github/workflows/reorder-versions.yaml
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

- follow up from: https://github.com/autowarefoundation/autoware-documentation/pull/718

https://github.com/autowarefoundation/autoware-documentation/actions/runs/19817067352

```
[Invalid workflow file: .github/workflows/deploy-docs.yaml#L79](https://github.com/autowarefoundation/autoware-documentation/actions/runs/19817067352/workflow)
error parsing called workflow
".github/workflows/deploy-docs.yaml"
-> "./.github/workflows/reorder-versions.yml"
: failed to fetch workflow: workflow was not found.
```

## How was this PR tested?

Because this is triggered on `pull_request_target` I'll be able to test it after it is merged.

Actually i can test it with workflow dispatch too I just realized:
https://github.com/autowarefoundation/autoware-documentation/actions/runs/19817191701/job/56770993776

This made me realize that they are running in parallel:

<img width="784" height="502" alt="image" src="https://github.com/user-attachments/assets/61cf20b1-8d31-4558-b093-dbca8d0a5333" />

I should make them sequential.

Will do in the next PR.

But at least the workflow file is valid now.

## Notes for reviewers

None.

## Effects on system behavior

None.
