### PR TITLE
ci(deploy-docs): add condition for reorder-versions-json job

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -76,6 +76,17 @@ jobs:
           mkdocs-requirements-txt: mkdocs-requirements.txt
 
   reorder-versions-json:
+    needs:
+      - deploy-docs-pr
+      - deploy-docs-push
+      - deploy-docs-workflow-dispatch
+    if: |
+      always() &&
+      (
+        needs.deploy-docs-pr.result == 'success' ||
+        needs.deploy-docs-push.result == 'success' ||
+        needs.deploy-docs-workflow-dispatch.result == 'success'
+      )
     uses: ./.github/workflows/reorder-versions.yaml
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

- follow up from: https://github.com/autowarefoundation/autoware-documentation/pull/718


I just realized that I can test it with workflow dispatch too :
https://github.com/autowarefoundation/autoware-documentation/actions/runs/19817191701/job/56770993776

This made me realize that they are running in parallel:

<img width="784" height="502" alt="image" src="https://github.com/user-attachments/assets/61cf20b1-8d31-4558-b093-dbca8d0a5333" />

This fixes that.

## How was this PR tested?

- https://github.com/autowarefoundation/autoware-documentation/actions/runs/19817383805

<img width="1291" height="630" alt="image" src="https://github.com/user-attachments/assets/abc4d576-004d-4de0-a341-e9ae0e907ee7" />

<img width="1282" height="608" alt="image" src="https://github.com/user-attachments/assets/b13c656e-d22a-4faf-8eef-2af849a8e2bd" />

🟢✅ green.

## Notes for reviewers

None.

## Effects on system behavior

None.
