### PR TITLE
ci(deploy-docs): remove latest version

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -58,7 +58,7 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/deploy-docs@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          latest: ${{ github.ref_name == github.event.repository.default_branch }}
+          latest: false
           mkdocs-requirements-txt: mkdocs-requirements.txt
 
   deploy-docs-workflow-dispatch:


### PR DESCRIPTION
## Description

Right now main and latest do build the same site twice. This increases the gh-pages size unnecessarily.

<img width="164" height="56" alt="image" src="https://github.com/user-attachments/assets/5e3e7379-8c4c-45ff-95b0-f0f5f6b91b9d" />

This PR removes it to avoid confusion and size.

## How was this PR tested?

Simple, no need.

## Notes for reviewers

None.

## Effects on system behavior

None.
