### PR TITLE
ci: fix and simplify github token passing

### DIFF
--- a/.github/workflows/delete-removed-branch-docs.yaml
+++ b/.github/workflows/delete-removed-branch-docs.yaml
@@ -2,11 +2,6 @@ name: delete-removed-branch-docs
 
 on:
   delete:
-  workflow_call:
-    secrets:
-      token:
-        description: GitHub token
-        required: true
   workflow_dispatch:
 
 jobs:
@@ -75,7 +70,7 @@ jobs:
       - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:
-          token: ${{ github.event_name == 'workflow_call' && secrets.token || secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Delete orphaned mike branch versions
         run: |

--- a/.github/workflows/reorder-versions.yaml
+++ b/.github/workflows/reorder-versions.yaml
@@ -87,17 +87,10 @@ jobs:
           mv versions.sorted.json versions.json
         shell: bash
 
-      - name: Set git config (workflow_call)
-        if: ${{ github.event_name == 'workflow_call' }}
+      - name: Set git config
         uses: autowarefoundation/autoware-github-actions/set-git-config@v1
         with:
-          token: ${{ secrets.token }}
-
-      - name: Set git config (workflow_dispatch)
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ github.event_name == 'workflow_dispatch' && secrets.GITHUB_TOKEN || secrets.token }}
 
       - name: Commit and push changes
         run: |


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/autoware-documentation/actions/runs/19824852330/job/56795648429?pr=188

<img width="1210" height="442" alt="image" src="https://github.com/user-attachments/assets/4197d251-704b-4d85-9510-449f08f597c9" />

We have this issue.

- It is similar to: https://github.com/actions/runner/issues/3146

Basically this is expected behavior, `if: ${{ github.event_name != 'workflow_call' }}` doesnt work. So I simplified the pathways to accommodate this.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
