### PR TITLE
chore: change dead polyfill.io to cloudflare mirror

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -50,7 +50,7 @@ extra_css:
 
 extra_javascript:
   - assets/js/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:


### PR DESCRIPTION
## Description

https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet/

> polyfill.io, a popular JavaScript library service, can no longer be trusted and should be removed from websites.

> [Multiple reports](https://sansec.io/research/polyfill-supply-chain-attack), corroborated with data seen by our own client-side security system, [Page Shield](https://developers.cloudflare.com/page-shield/), have shown that the polyfill service was being used, and could be used again, to inject malicious JavaScript code into users’ browsers. This is a real threat to the Internet at large given the popularity of this library.

https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk/

## How did you notice this?

<img width="2543" height="1439" alt="image" src="https://github.com/user-attachments/assets/70d4e434-fc19-4d22-9a8c-a4e37a96c773" />

<img width="2551" height="1300" alt="image" src="https://github.com/user-attachments/assets/cd0699e3-d813-445b-ae2b-cbf0e6aa4bec" />

If I open up a documentation page and press refresh, it takes forever for it to fully load.

Then I press F12 to open up the dev console. Go to Network section.

Then open up another autoware docs page and press F5 to reload.

I see relevant stuff load under 500ms.

But this polyfill thingy keep trying and lagging it.

It takes around 35 seconds to finally give up.

I try to manually load: https://polyfill.io/v3/polyfill.min.js?features=es6

❌ It doesn't load.

I google it to find out the issue.

Then I try: https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6

✅ It loads.

Then I make this PR.

## How was this PR tested?

Locally and on CI.