### PR TITLE
ci: reorder versions after delete-closed-pr-docs

### DIFF
--- a/.github/workflows/delete-closed-pr-docs.yaml
+++ b/.github/workflows/delete-closed-pr-docs.yaml
@@ -18,3 +18,10 @@ jobs:
         uses: autowarefoundation/autoware-github-actions/delete-closed-pr-docs@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+
+  reorder-versions-json:
+    needs:
+      - delete-closed-pr-docs
+    uses: ./.github/workflows/reorder-versions.yaml
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delete-removed-branch-docs.yaml
+++ b/.github/workflows/delete-removed-branch-docs.yaml
@@ -92,3 +92,10 @@ jobs:
               mike delete --push "branch-$MB"
             fi
           done
+
+  reorder-versions-json:
+    needs:
+      - delete-removed-branch-docs
+    uses: ./.github/workflows/reorder-versions.yaml
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

<img width="786" height="295" alt="image" src="https://github.com/user-attachments/assets/264555e9-d5ed-4184-bc31-934a7cb16dd9" />

<img width="357" height="193" alt="image" src="https://github.com/user-attachments/assets/e88957ae-546b-4a4c-9e02-5faae20c392e" />

Once the `delete-closed-pr-docs` or `delete-closed-pr-docs.yaml` workflows run and remove things, they rewrite the order of `version.json`.

This PR makes sure this reorder runs after they run.

## How was this PR tested?

## Notes for reviewers

None.

## Effects on system behavior

None.
