### PR TITLE
refactor: fix all broken self referential absolute links

### DIFF
--- a/docs/contributing/coding-guidelines/ros-nodes/launch-files.md
+++ b/docs/contributing/coding-guidelines/ros-nodes/launch-files.md
@@ -54,7 +54,7 @@ A33-->A43[twist2accel.launch.xml]
 
 ### Add a new package in Autoware
 
-If a newly created package has executable node, we expect sample launch file and configuration within the package, just like the recommended structure shown in previous [directory structure](https://autowarefoundation.github.io/autoware-documentation/main/contributing/coding-guidelines/ros-nodes/directory-structure/) page.
+If a newly created package has executable node, we expect sample launch file and configuration within the package, just like the recommended structure shown in the previous [directory structure](../../../contributing/coding-guidelines/ros-nodes/directory-structure.md) page.
 
 In order to automatically load the newly added package when starting Autoware, you need to make some necessary changes to the corresponding launch file. For example, if using ICP instead of NDT as the pointcloud registration algorithm, you can modify the `autoware_universe/launch/tier4_localization_launch/launch/pose_estimator/pose_estimator.launch.xml` file to load the newly added ICP package.
 

--- a/docs/design/autoware-architecture-v1/components/map/map-requirements/vector-map-requirements-overview/index.md
+++ b/docs/design/autoware-architecture-v1/components/map/map-requirements/vector-map-requirements-overview/index.md
@@ -10,7 +10,7 @@ Vector Map uses [lanelet2_extension](https://github.com/autowarefoundation/autow
 
 The primitives (basic components) used in Vector Map are explained in [Web.Auto Docs - What is Lanelet2](https://docs.web.auto/en/user-manuals/vector-map-builder/introduction#what-is-lanelet2). The following **Vector Map creation requirement specifications** are written on the premise of these knowledge.
 
-This specification is a set of requirements for the creation of Vector Map(s) to ensure that Autoware drives safely and autonomously as intended by the user. To Create a Lanelet2 format .osm file, please refer to [Creating a vector map](https://autowarefoundation.github.io/autoware-documentation/latest/how-to-guides/integrating-autoware/creating-maps/#creating-a-vector-map).
+This specification is a set of requirements for the creation of Vector Map(s) to ensure that Autoware drives safely and autonomously as intended by the user. To Create a Lanelet2 format .osm file, please refer to [Creating a vector map](../../../../../../tutorials/integrating-autoware/creating-maps/creating-vector-map/index.md).
 
 ## Handling of the Requirement Specification
 

--- a/docs/design/autoware-architecture-v1/components/perception/index.md
+++ b/docs/design/autoware-architecture-v1/components/perception/index.md
@@ -6,13 +6,13 @@ This document outlines the high-level design strategies, goals and related ratio
 
 ## Overview
 
-The Perception Component receives inputs from Sensing, Localization, and Map components, and adds semantic information (e.g., Object Recognition, Obstacle Segmentation, Traffic Light Recognition, Occupancy Grid Map), which is then passed on to Planning Component. This component design follows the overarching philosophy of Autoware, defined as the [microautonomy concept](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-concepts/).
+The Perception Component receives inputs from Sensing, Localization, and Map components, and adds semantic information (e.g., Object Recognition, Obstacle Segmentation, Traffic Light Recognition, Occupancy Grid Map), which is then passed on to Planning Component. This component design follows the overarching philosophy of Autoware, defined as the [microautonomy concept](../../../autoware-concepts/index.md).
 
 ## Goals and non-goals
 
 The role of the Perception Component is to recognize the surrounding environment based on the data obtained through Sensing and acquire sufficient information (such as the presence of dynamic objects, stationary obstacles, blind spots, and traffic signal information) to enable autonomous driving.
 
-In our overall design, we emphasize the concept of [microautonomy architecture](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-concepts). This term refers to a design approach that focuses on the proper modularization of functions, clear definition of interfaces between these modules, and as a result, high expandability of the system. Given this context, the goal of the Perception Component is set not to solve every conceivable complex use case (although we do aim to support basic ones), but rather to provide a platform that can be customized to the user's needs and can facilitate the development of additional features.
+In our overall design, we emphasize the concept of [microautonomy architecture](../../../autoware-concepts/index.md). This term refers to a design approach that focuses on the proper modularization of functions, clear definition of interfaces between these modules, and as a result, high expandability of the system. Given this context, the goal of the Perception Component is set not to solve every conceivable complex use case (although we do aim to support basic ones), but rather to provide a platform that can be customized to the user's needs and can facilitate the development of additional features.
 
 To clarify the design concepts, the following points are listed as goals and non-goals.
 

--- a/docs/design/autoware-architecture-v1/components/planning/index.md
+++ b/docs/design/autoware-architecture-v1/components/planning/index.md
@@ -12,7 +12,7 @@ The document is divided into two parts: the first part discusses high-level requ
 
 Our objective extends beyond merely developing an autonomous driving system. We aim to offer an "autonomous driving platform" where users can enhance autonomous driving functionalities based on their individual needs.
 
-In Autoware, we utilize the [microautonomy architecture](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-concepts) concept, which emphasizes high extensibility, functional modularity, and clearly defined interfaces.
+In Autoware, we utilize the [microautonomy architecture](../../../autoware-concepts/index.md) concept, which emphasizes high extensibility, functional modularity, and clearly defined interfaces.
 
 With this in mind, the design policy for the Planning Component is focused not on addressing every complex autonomous driving scenario (as that is a very challenging problem), but on **providing a customizable and easily extendable Planning development platform**. We believe this approach will allow the platform to meet a wide range of needs, ultimately solving many complex use cases.
 

--- a/docs/design/autoware-interfaces/components/perception-interface.md
+++ b/docs/design/autoware-interfaces/components/perception-interface.md
@@ -60,11 +60,11 @@ Image frame captured by camera.
 
 ### Vehicle kinematic state
 
-current position of ego, used in traffic signals recognition. See [output of Localization](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-interfaces/components/localization/#vehicle-kinematic-state).
+current position of ego, used in traffic signals recognition. See [output of Localization](localization.md#vehicle-kinematic-state).
 
 ### Lanelet2 Map
 
-map of the environment. See [outputs of Map](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-interfaces/components/map/#outputs).
+map of the environment. See [outputs of Map](map.md/#outputs).
 
 ## Output
 

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -18,8 +18,6 @@ sudo apt-get -y update
 sudo apt-get -y install git
 ```
 
-> Note: If you wish to use ROS 2 Galactic on Ubuntu 20.04, refer to installation instruction from [galactic](https://autowarefoundation.github.io/autoware-documentation/galactic/installation/autoware/source-installation/) branch, but be aware that Galactic version of Autoware might not have the latest features.
-
 ## How to set up a development environment
 
 1. Clone `autowarefoundation/autoware` and move to the directory.

--- a/docs/simulation-evaluation/components_evaluation/localization_evaluation/urban-environment-evaluation.md
+++ b/docs/simulation-evaluation/components_evaluation/localization_evaluation/urban-environment-evaluation.md
@@ -2,7 +2,7 @@
 
 #### Related Links
 
-Data Collection Documentation --> <https://autowarefoundation.github.io/autoware-documentation/main/datasets/#istanbul-open-dataset>
+Data Collection Documentation --> [İstanbul Open Dataset](../../../datasets/index.md#istanbul-open-dataset)
 
 #### Purpose
 
@@ -22,7 +22,7 @@ The data contains data from the following sensors:
 - 1 x Applanix POS LVX GNSS/INS System
 - 1 x Hesai Pandar XT32 LiDAR
 
-You can find the data collected for testing and mapping in this [Documentation](https://autowarefoundation.github.io/autoware-documentation/main/datasets/#istanbul-open-dataset).
+You can find the data collected for testing and mapping in this [İstanbul Open Dataset](../../../datasets/index.md#istanbul-open-dataset).
 
 > <span style="color:green">**NOTE !**</span> </br>  
 > Since there was no velocity source coming from the vehicle during all these tests, the twist message coming from GNSS/INS was given to ekf_localizer as the linear&angular velocity source. </br>

--- a/docs/tutorials/integrating-autoware/creating-vehicle-interface-package/ackermann-kinematic-model.md
+++ b/docs/tutorials/integrating-autoware/creating-vehicle-interface-package/ackermann-kinematic-model.md
@@ -7,7 +7,7 @@ Please remember,
 Autoware control output (/control/command/control_cmd)
 publishes lateral and longitudinal commands according to the Ackermann kinematic model.
 
-- If your vehicle does not suit the Ackermann kinematic model, you have to modify the control commands. [Another document gives you an example how to convert your Ackermann kinematic model control inputs into a differential drive model.](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-interface-package/customizing-for-differential-drive-model/)
+- If your vehicle does not suit the Ackermann kinematic model, you have to modify the control commands. [Another document gives you an example of how to convert your Ackermann kinematic model control inputs into a differential drive model.](customizing-for-differential-drive-model.md)
 
 ## Geometry
 
@@ -64,4 +64,4 @@ See the [AckermannLateralCommand.idl](https://gitlab.com/autowarefoundation/auto
 
 The vehicle interface should realize these control commands through your vehicle's control device.
 
-Moreover, Autoware also provides brake commands, light commands, and more (see [vehicle interface design](https://autowarefoundation.github.io/autoware-documentation/main/design/autoware-interfaces/components/vehicle-interface/)), so the vehicle interface module should be applicable to these commands as long as there are devices available to handle them.
+Moreover, Autoware also provides brake commands, light commands, and more (see [vehicle interface design](../../../design/autoware-interfaces/components/vehicle-interface.md)), so the vehicle interface module should be applicable to these commands as long as there are devices available to handle them.

--- a/docs/tutorials/integrating-autoware/creating-vehicle-interface-package/creating-vehicle-interface.md
+++ b/docs/tutorials/integrating-autoware/creating-vehicle-interface-package/creating-vehicle-interface.md
@@ -257,4 +257,4 @@ There are some tips that may help you.
     version: main
   ```
 
-  Then you can import your entire environment easily to another local device by using the `vcs import` command. (See [the source installation guide](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/#how-to-set-up-a-workspace))
+  Then you can import your entire environment easily to another local device by using the `vcs import` command. (See [the source installation guide](../../../installation/autoware/source-installation.md#how-to-set-up-a-workspace))

--- a/docs/tutorials/integrating-autoware/creating-your-autoware-repositories/creating-autoware-repositories.md
+++ b/docs/tutorials/integrating-autoware/creating-your-autoware-repositories/creating-autoware-repositories.md
@@ -173,7 +173,7 @@ on how to create and customize each of your vehicle's packages:
   - [Creating sensor model](../creating-vehicle-and-sensor-model/creating-sensor-model/index.md)
   - [Creating individual params](../creating-vehicle-and-sensor-model/creating-individual-params/index.md)
   - [Creating vehicle model](../creating-vehicle-and-sensor-model/creating-vehicle-model/index.md)
-- [creating-vehicle-interface-package](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-interface-package/creating-a-vehicle-interface-for-an-ackermann-kinematic-model/)
-- [customizing-for-differential-drive-model](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/integrating-autoware/creating-vehicle-interface-package/customizing-for-differential-drive-model/)
+- [creating-vehicle-interface-package](../creating-vehicle-interface-package/ackermann-kinematic-model.md)
+- [customizing-for-differential-drive-model](../creating-vehicle-interface-package/customizing-for-differential-drive-model.md)
 
 Please remember to add all your custom packages, such as interfaces and descriptions, to your `autoware.repos` to ensure that your packages are properly included and managed within the Autoware repository.

--- a/docs/tutorials/others/an-example-procedure-for-adding-and-evaluating-a-new-node.md
+++ b/docs/tutorials/others/an-example-procedure-for-adding-and-evaluating-a-new-node.md
@@ -16,8 +16,8 @@ Autoware constantly incorporates new features.
 It is crucial to initially confirm that it operates as expected with the current version, which helps in problem troubleshooting.
 
 In this context, AWSIM is presumed.
-Therefore, [AWSIM simulator](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/digital-twin-simulation/awsim-tutorial/) can be useful.
-If you are using actual hardware, please refer to the [How-to guides](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/).
+Therefore, [AWSIM simulator demo](../../demos/digital-twin-demos/awsim-tutorial.md) can be useful.
+If you are using actual hardware, please refer to the [Tutorials](../index.md).
 
 ## 2. Recording a rosbag using Autoware
 
@@ -37,7 +37,7 @@ This verification can be accomplished, for example, by inspecting the image data
 
 When developing a new node, it could be beneficial to reference a package that is similar to the one you intend to create.
 
-It is advisable to thoroughly read the [Design page](https://autowarefoundation.github.io/autoware-documentation/main/design/), contemplate the addition or replacement of nodes in Autoware, and then implement your solution.
+It is advisable to thoroughly read the [Design page](../../design/index.md), contemplate the addition or replacement of nodes in Autoware, and then implement your solution.
 
 For example, a node doing NDT, a LiDAR-based localization method, is [ndt_scan_matcher](https://github.com/autowarefoundation/autoware_universe/tree/main/localization/autoware_ndt_scan_matcher).
 If you want to replace this with a different approach, implement a node which produces the same topics and provides the same services.
@@ -47,7 +47,7 @@ If you want to replace this with a different approach, implement a node which pr
 ## 4. Evaluating by a rosbag-based simulator
 
 Once the new node is implemented, it is time to evaluate it.
-[logging_simulator](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/) is a tool of how to evaluate the new node using the rosbag captured in step 2.
+[logging_simulator](../../demos/rosbag-replay-simulation.md) is a tool of how to evaluate the new node using the rosbag captured in step 2.
 
 When you run the logging_simulator, you can set `planning:=false` or `control:=false` to disable the launch of specific component nodes.
 
@@ -64,7 +64,7 @@ There is [ros2bag_extensions](https://github.com/tier4/ros2bag_extensions) avail
 
 Once you have sufficiently verified the behavior in the logging_simulator, let's run it as Autoware with new nodes added in the realtime environment.
 
-To debug Autoware, the method described at [debug-autoware](https://autowarefoundation.github.io/autoware-documentation/main/how-to-guides/others/debug-autoware/) is useful.
+To debug Autoware, the method described at [debug-autoware](debug-autoware.md) is useful.
 
 For reproducibility, you may want to fix the GoalPose.
 In such cases, consider using the [tier4_automatic_goal_rviz_plugin](https://github.com/autowarefoundation/autoware_tools/tree/main/common/tier4_automatic_goal_rviz_plugin).

--- a/docs/tutorials/others/planning-evaluation-using-scenarios.md
+++ b/docs/tutorials/others/planning-evaluation-using-scenarios.md
@@ -107,7 +107,7 @@ vcs import src < simulator.repos
 
 - If you are installing Autoware for the first time, you can automatically install the dependencies by using the
   provided Ansible script. Please refer to
-  the [Autoware source installation page](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/)
+  the [Autoware source installation page](../../installation/autoware/source-installation.md)
   for more information.
 
 ```bash
@@ -132,7 +132,7 @@ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
 ```
 
 - If you have any issues with the installation, or if you need more detailed instructions, please refer to the
-  [Autoware source installation page](https://autowarefoundation.github.io/autoware-documentation/main/installation/autoware/source-installation/).
+  [Autoware source installation page](../../installation/autoware/source-installation.md)
 
 ### Execute the scenario by using Scenario Simulator
 

--- a/docs/tutorials/others/using-divided-map.md
+++ b/docs/tutorials/others/using-divided-map.md
@@ -21,7 +21,7 @@ ros2 launch autoware_launch logging_simulator.launch.xml \
   vehicle_model:=sample_vehicle_split sensor_model:=sample_sensor_kit
 ```
 
-For playing rosbag to simulate Autoware, please refer to the instruction in [the tutorial for rosbag replay simulation](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/).
+For playing rosbag to simulate Autoware, please refer to the instruction in [the demo for rosbag replay simulation](../../demos/rosbag-replay-simulation.md).
 
 ## Related links
 


### PR DESCRIPTION
## Description

This fixes all the self referential absolute links.

- Mostly converted to relative links.
- Some minor fixes.
- Removed galactic dead link.

When absolute links are broken, the mike deploy cannot catch them.

So we shouldn't have any absolute links that self reference within the documentation.

## How was this PR tested?

Tested by the deploy-docs workflow.
