### PR TITLE
docs: fix incorrect sample vehicle/sensor model names in launch command docs

### DIFF
--- a/docs/demos/digital-twin-demos/carla-tutorial.md
+++ b/docs/demos/digital-twin-demos/carla-tutorial.md
@@ -29,7 +29,7 @@ TensorRT-optimized Vectorized Autonomous Driving ([VAD](https://github.com/hustv
      ```bash
      ros2 launch autoware_launch e2e_simulator.launch.xml \
        map_path:=$HOME/autoware_map/Town01 \
-       vehicle_model:=autoware_sample_vehicle \
+       vehicle_model:=sample_vehicle \
        sensor_model:=carla_sensor_kit \
        simulator_type:=carla \
        use_e2e_planning:=true \

--- a/docs/demos/planning-sim/index.md
+++ b/docs/demos/planning-sim/index.md
@@ -39,7 +39,7 @@ If not, please, follow [Manual downloading of artifacts](https://github.com/auto
 
 ```bash
 source ~/autoware/install/setup.bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=autoware_sample_vehicle sensor_model:=autoware_sample_sensor_kit
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
 ```
 
 !!! warning

--- a/docs/demos/planning-sim/lane-change.md
+++ b/docs/demos/planning-sim/lane-change.md
@@ -11,7 +11,7 @@
 
    ```bash
    source ~/autoware/install/setup.bash
-   ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/nishishinjuku_autoware_map vehicle_model:=autoware_sample_vehicle sensor_model:=autoware_sample_sensor_kit
+   ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/nishishinjuku_autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
    ```
 
    ![open-nishishinjuku-map](images/lane-change/open-nishishinjuku-map.png)

--- a/docs/demos/planning-sim/lane-driving.md
+++ b/docs/demos/planning-sim/lane-driving.md
@@ -4,7 +4,7 @@
 
 ```bash
 source ~/autoware/install/setup.bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=autoware_sample_vehicle sensor_model:=autoware_sample_sensor_kit
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
 ```
 
 !!! warning

--- a/docs/demos/rosbag-replay-simulation.md
+++ b/docs/demos/rosbag-replay-simulation.md
@@ -53,7 +53,7 @@
 
    ```sh
    source ~/autoware/install/setup.bash
-   ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-rosbag vehicle_model:=autoware_sample_vehicle sensor_model:=autoware_sample_sensor_kit
+   ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
    ```
 
    Note that you cannot use `~` instead of `$HOME` here.

--- a/docs/demos/scenario-simulation/scenario-simulator/random-test-simulation.md
+++ b/docs/demos/scenario-simulation/scenario-simulator/random-test-simulation.md
@@ -19,8 +19,8 @@
    ```bash
    ros2 launch random_test_runner random_test.launch.py \
      architecture_type:=awf/universe/20250130 \
-     sensor_model:=autoware_sample_sensor_kit \
-     vehicle_model:=autoware_sample_vehicle
+     sensor_model:=sample_sensor_kit \
+     vehicle_model:=sample_vehicle
    ```
 
 ![random_test_runner](images/random_test_runner.png)

--- a/docs/demos/scenario-simulation/scenario-simulator/scenario-test-simulation.md
+++ b/docs/demos/scenario-simulation/scenario-simulator/scenario-test-simulation.md
@@ -21,8 +21,8 @@
      architecture_type:=awf/universe/20250130 \
      record:=false \
      scenario:='$(find-pkg-share scenario_test_runner)/scenario/sample.yaml' \
-     sensor_model:=autoware_sample_sensor_kit \
-     vehicle_model:=autoware_sample_vehicle \
+     sensor_model:=sample_sensor_kit \
+     vehicle_model:=sample_vehicle \
      use_custom_centerline:=true \
      rviz_config:=$(ros2 pkg prefix autoware_launch)/share/autoware_launch/rviz/scenario_simulator.rviz
    ```

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -59,7 +59,7 @@ For more launch options, you can append a custom launch command instead of using
 Here is an example of running the runtime container with a custom launch command:
 
 ```bash
-./docker/run.sh --map-path ~/autoware_map/sample-map-rosbag --data-path ~/autoware_data ros2 launch autoware_launch planning_simulator.launch.xml map_path:=/autoware_map vehicle_model:=autoware_sample_vehicle sensor_model:=autoware_sample_sensor_kit
+./docker/run.sh --map-path ~/autoware_map/sample-map-rosbag --data-path ~/autoware_data ros2 launch autoware_launch planning_simulator.launch.xml map_path:=/autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
 ```
 
 !!! info

--- a/docs/simulation-evaluation/components_evaluation/localization_evaluation/urban-environment-evaluation.md
+++ b/docs/simulation-evaluation/components_evaluation/localization_evaluation/urban-environment-evaluation.md
@@ -107,7 +107,7 @@ colcon build --symlink-install --packages-select sample_sensor_kit_launch autowa
 
 ```bash
 source ~/autoware/install/setup.bash
-ros2 launch autoware_launch logging_simulator.launch.xml map_path:=~/autoware_ista_map/ vehicle_model:=autoware_sample_vehicle sensor_model:=autoware_sample_sensor_kit
+ros2 launch autoware_launch logging_simulator.launch.xml map_path:=~/autoware_ista_map/ vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
 ```
 
 ##### Run Rosbag

--- a/docs/tutorials/others/planning-evaluation-using-scenarios.md
+++ b/docs/tutorials/others/planning-evaluation-using-scenarios.md
@@ -162,8 +162,8 @@ define a dummy file for this field.
 ros2 launch scenario_test_runner scenario_test_runner.launch.py \
 record:=false \
 scenario:='/path/to/scenario/sample.yaml' \
-sensor_model:=autoware_sample_sensor_kit \
-vehicle_model:=autoware_sample_vehicle \
+sensor_model:=sample_sensor_kit \
+vehicle_model:=sample_vehicle \
 use_custom_centerline:=true \
 rviz_config:=$(ros2 pkg prefix autoware_launch)/share/autoware_launch/rviz/scenario_simulator.rviz
 ```

--- a/docs/tutorials/others/using-divided-map.md
+++ b/docs/tutorials/others/using-divided-map.md
@@ -18,7 +18,7 @@ Note that you need to specify the `map_path` and `pointcloud_map_file` arguments
 source ~/autoware/install/setup.bash
 ros2 launch autoware_launch logging_simulator.launch.xml \
   map_path:=$HOME/autoware_map/sample-map-rosbag pointcloud_map_file:=pointcloud_map \
-  vehicle_model:=autoware_sample_vehicle_split sensor_model:=autoware_sample_sensor_kit
+  vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
 ```
 
 For playing rosbag to simulate Autoware, please refer to the instruction in [the demo for rosbag replay simulation](../../demos/rosbag-replay-simulation.md).


### PR DESCRIPTION
This PR fixes outdated launch command examples that used incorrect sample model names in Autoware documentation.

Several docs used:

- `vehicle_model:=autoware_sample_vehicle`
- `sensor_model:=autoware_sample_sensor_kit`

For current `autoware_launch`/simulation usage, these should be:

- `vehicle_model:=sample_vehicle`
- `sensor_model:=sample_sensor_kit`

The mismatch caused launch failures such as missing package resolution for `autoware_sample_vehicle_launch`.