### PR TITLE
docs: update CUDA version link from .env to ansible role defaults

### DIFF
--- a/docs/community/support/troubleshooting/index.md
+++ b/docs/community/support/troubleshooting/index.md
@@ -50,7 +50,7 @@ When installing CUDA, errors may occur because of version conflicts. To resolve 
 
 !!! warning
 
-    Note that some components in Autoware Universe require CUDA, and only the CUDA version in the [env file](https://github.com/autowarefoundation/autoware/blob/main/amd64.env) is supported at this time.
+    Note that some components in Autoware Universe require CUDA, and only the CUDA version in the [cuda role defaults](https://github.com/autowarefoundation/autoware/blob/main/ansible/roles/cuda/defaults/main.yaml) is supported at this time.
     Autoware may work with other CUDA versions, but those versions are not supported and functionality is not guaranteed.
 
 ## Build issues


### PR DESCRIPTION
- **Parent Issue:** autowarefoundation/autoware#6938
- Update the CUDA version reference link in the [troubleshooting page](https://github.com/autowarefoundation/autoware-documentation/blob/c8f757a38c7bd8978744a33e856b0528e450bc54/docs/community/support/troubleshooting/index.md) from the soon-to-be-deleted `amd64.env` to `ansible/roles/cuda/defaults/main.yaml`, the new single source of truth.

## Why

The `.env` files in the autoware repo are being removed as part of the refactor to make ansible role defaults the single source of truth for version pins. This link would otherwise break.

---

- Depends on autowarefoundation/autoware#6962

## Test plan

- [ ] Verify the [new link](https://github.com/autowarefoundation/autoware/blob/main/ansible/roles/cuda/defaults/main.yaml) resolves correctly on GitHub