### PR TITLE
docs: migrate ansible instructions off setup-dev-env.sh

### DIFF
--- a/docs/community/support/troubleshooting/index.md
+++ b/docs/community/support/troubleshooting/index.md
@@ -6,7 +6,7 @@
 
 When installing CUDA, errors may occur because of version conflicts. To resolve these types of errors, try one of the following methods:
 
-- Unhold all CUDA-related libraries and rerun the setup script.
+- Unhold all CUDA-related libraries and rerun the playbook.
 
   ```bash
   sudo apt-mark unhold  \
@@ -18,10 +18,10 @@ When installing CUDA, errors may occur because of version conflicts. To resolve 
     "tensorrt*"         \
     "nvidia*"
 
-  ./setup-dev-env.sh
+  ansible-playbook autoware.dev_env.install_dev_env
   ```
 
-- Uninstall all CUDA-related libraries and rerun the setup script.
+- Uninstall all CUDA-related libraries and rerun the playbook.
 
   ```bash
   sudo apt purge        \
@@ -35,17 +35,17 @@ When installing CUDA, errors may occur because of version conflicts. To resolve 
 
   sudo apt autoremove
 
-  ./setup-dev-env.sh
+  ansible-playbook autoware.dev_env.install_dev_env
   ```
 
 !!! warning
 
     Note that this may break your system and run carefully.
 
-- Run the setup script without installing CUDA-related libraries.
+- Run the playbook without installing CUDA-related libraries.
 
   ```bash
-  ./setup-dev-env.sh --no-nvidia
+  ansible-playbook autoware.dev_env.install_dev_env --skip-tags nvidia
   ```
 
 !!! warning

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -22,22 +22,24 @@ Open AD Kit offers two types of Docker image to let you get started with Autowar
    cd autoware
    ```
 
-2. The [setup script](https://github.com/autowarefoundation/autoware/blob/main/setup-dev-env.sh) will install all required dependencies with:
+2. Install Ansible and run the Docker setup playbook:
 
    ```bash
-   ./setup-dev-env.sh -y docker
+   bash ansible/scripts/install-ansible.sh
+   ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
+   ansible-playbook autoware.dev_env.install_docker
    ```
 
    To install without **NVIDIA GPU** support:
 
    ```bash
-   ./setup-dev-env.sh -y --no-nvidia docker
+   ansible-playbook autoware.dev_env.install_docker --skip-tags nvidia
    ```
 
    To download only the artifacts:
 
    ```bash
-   ./setup-dev-env.sh -y download_artifacts
+   ansible-playbook autoware.dev_env.install_dev_env --tags artifacts
    ```
 
 !!! info

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -27,10 +27,18 @@ sudo apt-get -y install git
    cd autoware
    ```
 
-2. If you are installing Autoware for the first time, you can automatically install the dependencies by using the provided Ansible script.
+2. If you are installing Autoware for the first time, you can automatically install the dependencies by using the provided Ansible playbook.
 
    ```bash
-   ./setup-dev-env.sh
+   bash ansible/scripts/install-ansible.sh
+   ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
+   ansible-playbook autoware.dev_env.install_dev_env
+   ```
+
+   To install without **NVIDIA GPU** support:
+
+   ```bash
+   ansible-playbook autoware.dev_env.install_dev_env --skip-tags nvidia
    ```
 
    If you encounter any build issues, please consult the [Troubleshooting](../../community/support/troubleshooting/index.md#build-issues) section for assistance.

--- a/docs/tutorials/others/planning-evaluation-using-scenarios.md
+++ b/docs/tutorials/others/planning-evaluation-using-scenarios.md
@@ -106,12 +106,14 @@ vcs import src < repositories/simulator.repos
 ```
 
 - If you are installing Autoware for the first time, you can automatically install the dependencies by using the
-  provided Ansible script. Please refer to
+  provided Ansible playbook. Please refer to
   the [Autoware source installation page](../../installation/autoware/source-installation.md)
   for more information.
 
 ```bash
-./setup-dev-env.sh
+bash ansible/scripts/install-ansible.sh
+ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
+ansible-playbook autoware.dev_env.install_dev_env
 ```
 
 - Install dependent ROS packages.


### PR DESCRIPTION
## Summary

- Migrates the documentation off `setup-dev-env.sh` and the legacy
`universe.yaml` / `docker.yaml` playbooks, in coordination with the
ansible refactor in autowarefoundation/autoware#7052 (Phase 1, step 7).

---

- `./setup-dev-env.sh [-y] docker` → `bash ansible/scripts/install-ansible.sh` + `ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml` + `ansible-playbook autoware.dev_env.install_docker`
- `./setup-dev-env.sh` → same bootstrap with `ansible-playbook autoware.dev_env.install_dev_env`
- `--no-nvidia` → `--skip-tags nvidia`
- `download_artifacts` → `--tags artifacts`

Files updated:

- `docs/installation/autoware/docker-installation.md`
- `docs/installation/autoware/source-installation.md`
- `docs/community/support/troubleshooting/index.md`
- `docs/tutorials/others/planning-evaluation-using-scenarios.md`

## Test plan

- [x] `mkdocs serve` renders all four pages without errors
- [x] Manually skim each updated page for broken anchors/code blocks