### PR TITLE
docs(installation): replace removed docker/run.sh and docker/build.sh refs

### DIFF
--- a/docs/community/support/troubleshooting/index.md
+++ b/docs/community/support/troubleshooting/index.md
@@ -172,7 +172,7 @@ docker run --rm -it ubuntu:latest
 Next, confirm that you are able to access the base Autoware image that is stored on the GitHub Packages website
 
 ```bash
-docker run --rm -it ghcr.io/autowarefoundation/autoware-universe:latest
+docker run --rm -it ghcr.io/autowarefoundation/autoware:universe-jazzy
 ```
 
 ## Runtime issues

--- a/docs/demos/digital-twin-demos/autoware-core-awsim/index.md
+++ b/docs/demos/digital-twin-demos/autoware-core-awsim/index.md
@@ -68,7 +68,6 @@ If you have not yet installed Autoware, please refer to the [Installation](../..
 2. Run the following command in the docker container.
 
    ```bash
-   apt update && apt install ros-humble-topic-tools
    ros2 launch autoware_core autoware_core.launch.xml use_sim_time:=true map_path:=/home/aw/autoware_map vehicle_model:=autoware_sample_vehicle sensor_model:=autoware_awsim_sensor_kit
    ```
 

--- a/docs/demos/digital-twin-demos/autoware-core-awsim/index.md
+++ b/docs/demos/digital-twin-demos/autoware-core-awsim/index.md
@@ -62,14 +62,14 @@ If you have not yet installed Autoware, please refer to the [Installation](../..
 
    ```bash
    xhost +local:
-   docker run --rm -it --net host -e DISPLAY=$DISPLAY -v $HOME/Downloads/Shinjuku-Map/map:/autoware/map ghcr.io/autowarefoundation/autoware:core
+   docker run --rm -it --net host -e DISPLAY=$DISPLAY -v $HOME/Downloads/Shinjuku-Map/map:/home/aw/autoware_map ghcr.io/autowarefoundation/autoware:core-humble
    ```
 
 2. Run the following command in the docker container.
 
    ```bash
    apt update && apt install ros-humble-topic-tools
-   ros2 launch autoware_core autoware_core.launch.xml use_sim_time:=true map_path:=/autoware/map vehicle_model:=autoware_sample_vehicle sensor_model:=autoware_awsim_sensor_kit
+   ros2 launch autoware_core autoware_core.launch.xml use_sim_time:=true map_path:=/home/aw/autoware_map vehicle_model:=autoware_sample_vehicle sensor_model:=autoware_awsim_sensor_kit
    ```
 
 ## Launch Autoware for source installation

--- a/docs/installation/autoware/core-docker-installation.md
+++ b/docs/installation/autoware/core-docker-installation.md
@@ -8,15 +8,17 @@
 
 ## Select docker image
 
-| Image                                          | Description                                                               |
-| ---------------------------------------------- | ------------------------------------------------------------------------- |
-| ghcr.io/autowarefoundation/autoware:core       | This is a runtime image that contains only the executables.               |
-| ghcr.io/autowarefoundation/autoware:core-devel | This is a develop image that contains source code and build dependencies. |
+| Image                                                | Description                                                               |
+| ---------------------------------------------------- | ------------------------------------------------------------------------- |
+| ghcr.io/autowarefoundation/autoware:core-jazzy       | This is a runtime image that contains only the executables.               |
+| ghcr.io/autowarefoundation/autoware:core-devel-jazzy | This is a develop image that contains source code and build dependencies. |
+
+Replace `jazzy` with `humble` for ROS 2 Humble. Tag scheme: `<stage>-<ros_distro>[-<date>|-<version>]`. The full image catalog and tag list lives in [`autoware/docker/README.md`](https://github.com/autowarefoundation/autoware/blob/main/docker/README.md).
 
 ## How to set up
 
-Pull the Docker image you want to use. The following command is for autoware:core.
+Pull the Docker image you want to use. The following command is for `core-jazzy`:
 
 ```bash
-docker pull ghcr.io/autowarefoundation/autoware:core
+docker pull ghcr.io/autowarefoundation/autoware:core-jazzy
 ```

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -1,13 +1,28 @@
-# Open AD Kit: Containerized workloads for Autoware
+# Docker installation
 
-Open AD Kit offers two types of Docker image to let you get started with Autoware quickly: `devel` and `runtime`.
+Autoware publishes prebuilt multi-arch (amd64, arm64) Docker images on GHCR. There are runtime images for trying things out, devel images for building locally, and CUDA variants for GPU workloads.
 
-1. The `devel` image enables you to develop Autoware without setting up the local development environment.
-2. The `runtime` image contains only runtime executables and enables you to try out Autoware quickly.
+The full image catalog — twelve images organized as a build graph — is documented in the canonical Docker reference next to the Dockerfiles in the `autoware` repository. Bookmark these sections, since they track the implementation:
+
+- [`docker/README.md` → Image Graph](https://github.com/autowarefoundation/autoware/blob/main/docker/README.md#image-graph) — visual diagram of how the images depend on each other.
+- [`docker/README.md` → Images](https://github.com/autowarefoundation/autoware/blob/main/docker/README.md#images) — table describing each image and when to use it.
+- [`docker/README.md` → Pull from GHCR](https://github.com/autowarefoundation/autoware/blob/main/docker/README.md#pull-from-ghcr) — tag pattern (`<stage>-<ros_distro>[-<date>|-<version>]`) and `docker pull` examples for every variant.
+
+The two images most users will care about:
+
+- `ghcr.io/autowarefoundation/autoware:universe-cuda-jazzy` — full Autoware runtime with NVIDIA CUDA, cuDNN, and TensorRT bundled.
+- `ghcr.io/autowarefoundation/autoware:universe-jazzy` — full Autoware runtime, no GPU.
+
+Replace `jazzy` with `humble` for ROS 2 Humble.
+
+For the broader containerized-deployment story (deployment patterns, integrations, edge use cases), see Open AD Kit:
+
+- <https://github.com/autowarefoundation/openadkit>
+- <https://autowarefoundation.github.io/openadkit/>
 
 !!! info
 
-    Before proceeding, confirm and agree with the [NVIDIA Deep Learning Container license](https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license). By pulling and using the Autoware Open AD Kit images, you accept the terms and conditions of the license.
+    Before proceeding, confirm and agree with the [NVIDIA Deep Learning Container license](https://developer.nvidia.com/ngc/nvidia-deep-learning-container-license). By pulling and using Autoware's CUDA images, you accept the terms and conditions of the license.
 
 ## Prerequisites
 
@@ -50,23 +65,15 @@ Open AD Kit offers two types of Docker image to let you get started with Autowar
 
 ### Launching the runtime container
 
-You can use `run.sh` to run the Autoware runtime container with the map and data (artifacts) paths:
+The runtime image runs `ros2 launch autoware_launch autoware.launch.xml` on container start. The canonical `docker run` invocation — with map and data volumes, X11 forwarding, CUDA passthrough, and a flag-by-flag rationale table — is in [`docker/README.md` → Usage](https://github.com/autowarefoundation/autoware/blob/main/docker/README.md#usage). The same section covers the no-GPU variant (drop the NVIDIA-related flags) and how to override the default CycloneDDS config when you need ROS 2 nodes to reach across hosts.
 
-```bash
-./docker/run.sh --map-path path_to_map --data-path path_to_data
-```
+### Pre-configured demo scenarios
 
-For more launch options, you can append a custom launch command instead of using the default launch command which is `ros2 launch autoware_launch autoware.launch.xml`.
+Rather than crafting your own `docker run` command, the [`docker/examples/demos/`](https://github.com/autowarefoundation/autoware/tree/main/docker/examples/demos) folder ships ready-to-run Compose stacks. Each demo has its own README with prerequisites and run commands:
 
-Here is an example of running the runtime container with a custom launch command:
-
-```bash
-./docker/run.sh --map-path ~/autoware_map/sample-map-rosbag --data-path ~/autoware_data ros2 launch autoware_launch planning_simulator.launch.xml map_path:=/autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
-```
-
-!!! info
-
-    Use `--no-nvidia` to run without NVIDIA GPU support, and `--headless` to run without display (no RViz visualization).
+- [**planning-simulator**](https://github.com/autowarefoundation/autoware/tree/main/docker/examples/demos/planning-simulator) — Planning simulator with the sample map, vehicle, and sensor kit. Three rendering paths via Compose overlays: software rendering by default, `docker-compose.dri.yaml` for Intel/AMD/Nouveau hosts, `docker-compose.nvidia.yaml` for NVIDIA proprietary.
+- [**awsim**](https://github.com/autowarefoundation/autoware/tree/main/docker/examples/demos/awsim) — Bridges Autoware to the [AWSIM](https://tier4.github.io/AWSIM/) Unity simulator over `network_mode: host` and launches `e2e_simulator.launch.xml`. Requires NVIDIA + the Container Toolkit.
+- [**scenario-simulator**](https://github.com/autowarefoundation/autoware/tree/main/docker/examples/demos/scenario-simulator) — Runs a `scenario_simulator_v2` scenario against a live Autoware planning stack as two services that share a generated CycloneDDS config.
 
 ### Running Autoware tutorials
 
@@ -82,13 +89,24 @@ Open AD Kit provides different deployment options for Autoware, so that you can 
 
 ## Development
 
+For developing against Autoware (rather than just running it), the [`docker/examples/basic/`](https://github.com/autowarefoundation/autoware/tree/main/docker/examples/basic) folder ships three Compose files — each a "drop me into a shell" container built on the `universe-devel-*` images, with `~/autoware_map`, `~/autoware_data`, and the autoware source tree mounted. Pick the flavor that matches your host:
+
+| Host GPU / driver            | Compose file                                |
+| ---------------------------- | ------------------------------------------- |
+| NVIDIA + proprietary driver  | `dev-nvidia.compose.yaml` (recommended)     |
+| NVIDIA + Nouveau open driver | `dev-dri.compose.yaml`                      |
+| Intel / AMD                  | `dev-dri.compose.yaml`                      |
+| No GPU / headless            | `dev-cpu.compose.yaml` (software rendering) |
+
+From the autoware repo root:
+
 ```bash
-./docker/run.sh --devel
+xhost +local:docker
+HOST_UID=$(id -u) HOST_GID=$(id -g) \
+  docker compose -f docker/examples/basic/dev-nvidia.compose.yaml run --rm autoware
 ```
 
-!!! info
-
-    By default workspace mounted on the container will be current directory(pwd), you can change the workspace path by `--workspace path_to_workspace`. For development environments without NVIDIA GPU support use `--no-nvidia`.
+[`docker/examples/basic/README.md`](https://github.com/autowarefoundation/autoware/blob/main/docker/examples/basic/README.md) goes deeper: how to verify you actually got hardware acceleration (`glxinfo -B`), why `dev-dri` silently falls back to software rendering on NVIDIA proprietary, and how to attach a second terminal to a running dev container.
 
 ### How to set up a workspace
 
@@ -172,39 +190,18 @@ Using the [Visual Studio Code](https://code.visualstudio.com/) with the [Remote 
 Get the Visual Studio Code's [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension.
 And reopen the workspace in the container by selecting `Remote-Containers: Reopen in Container` from the Command Palette (`F1`).
 
-You can choose Autoware or Autoware-cuda image to develop with or without CUDA support.
+You can choose the `universe-devel-jazzy` or `universe-devel-cuda-jazzy` image to develop without or with CUDA support.
 
 ### Building Docker images from scratch
 
-If you want to build these images locally for development purposes, run the following command:
+The build pipeline uses [`docker buildx bake`](https://docs.docker.com/build/bake/) driven by [`docker/docker-bake.hcl`](https://github.com/autowarefoundation/autoware/blob/main/docker/docker-bake.hcl). Building any target beyond `base` requires the autoware source repositories checked out under `src/`:
 
 ```bash
 cd autoware/
-./docker/build.sh
+vcs import src < repositories/autoware.repos
+docker buildx bake -f docker/docker-bake.hcl
 ```
 
-To build without CUDA, use the `--no-cuda` option:
+That builds the default targets (`universe` and `universe-cuda`); dependencies in the [image graph](https://github.com/autowarefoundation/autoware/blob/main/docker/README.md#image-graph) are resolved automatically. To target a specific stage (e.g. `core-devel`, `base-cuda-runtime`), pass it as an argument; to build for ROS 2 Humble, prefix with `ROS_DISTRO=humble`. See [`docker/README.md` → Build locally](https://github.com/autowarefoundation/autoware/blob/main/docker/README.md#build-locally) for the full target list and multi-arch flow.
 
-```bash
-./docker/build.sh --no-cuda
-```
-
-To build only development image, use the `--devel-only` option:
-
-```bash
-./docker/build.sh --devel-only
-```
-
-To specify the platform, use the `--platform` option:
-
-```bash
-./docker/build.sh --platform linux/amd64
-./docker/build.sh --platform linux/arm64
-```
-
-#### Using Docker images other than `latest`
-
-There are also images versioned based on the `date` or `release tag`.  
-Use them when you need a fixed version of the image.
-
-The list of versions can be found [here](https://github.com/autowarefoundation/autoware/packages).
+Pinned date- and release-tagged versions of every image are published on [GHCR](https://github.com/autowarefoundation/autoware/pkgs/container/autoware) — use them when you need a fixed version of the image.

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -58,9 +58,9 @@ For installation types, see the subsections below. If any issues occur during in
 
 ### 1. Docker installation
 
-Autoware's Open AD Kit containers enable you to run and develop Autoware easily on your host machine, ensuring the same environment for development and deployment without installing dependencies.
+Autoware publishes prebuilt Docker images on GHCR that let you run and develop Autoware easily on your host machine, ensuring the same environment for development and deployment without installing dependencies.
 
-[Open AD Kit](https://autoware.org/open-ad-kit/) is the first [SOAFEE Blueprint](https://www.soafee.io/charter/) for autonomous driving, offering extensible modular containerized workloads to simplify running Autoware's AD stack on distributed systems. Refer to the [Open AD Kit Documentation](https://autowarefoundation.github.io/openadkit/) for more details.
+For containerized deployment patterns and integrations beyond local development, see [Open AD Kit](https://autoware.org/open-ad-kit/) — the first [SOAFEE Blueprint](https://www.soafee.io/charter/) for autonomous driving — and the [Open AD Kit Documentation](https://autowarefoundation.github.io/openadkit/).
 
 <div style="text-align: center;" markdown="1">
 


### PR DESCRIPTION
- **Parent Issue:** autowarefoundation/autoware#7074
- Replaces every reference to `./docker/run.sh` and `./docker/build.sh` (removed from `autowarefoundation/autoware` in commit `7731e15`, PR autowarefoundation/autoware#7040) with the current `docker run` / `docker compose` / `docker buildx bake` workflow.
- Drops the "Open AD Kit" framing on [`docs/installation/autoware/docker-installation.md`](https://github.com/autowarefoundation/autoware-documentation/blob/87d3c9e9c6a4802628f66c425832c4b683813096/docs/installation/autoware/docker-installation.md) and defers per-command details to upstream `autoware/docker/README.md` and `autoware/docker/examples/**/README.md` via deep links into specific anchors (`#image-graph`, `#images`, `#pull-from-ghcr`, `#usage`, `#build-locally`), so the docs side stays lean and tracks the source of truth.
- Fixes stale image tags in three sibling pages: [`core-docker-installation.md`](https://github.com/autowarefoundation/autoware-documentation/blob/87d3c9e9c6a4802628f66c425832c4b683813096/docs/installation/autoware/core-docker-installation.md) (`:core` / `:core-devel` → `:core-jazzy` / `:core-devel-jazzy`), [`community/support/troubleshooting/index.md`](https://github.com/autowarefoundation/autoware-documentation/blob/87d3c9e9c6a4802628f66c425832c4b683813096/docs/community/support/troubleshooting/index.md) (`autoware-universe:latest` → `autoware:universe-jazzy`), and the [`autoware-core-awsim`](https://github.com/autowarefoundation/autoware-documentation/blob/87d3c9e9c6a4802628f66c425832c4b683813096/docs/demos/digital-twin-demos/autoware-core-awsim/index.md) demo (`:core` → `:core-humble`, in-container mount path `/autoware/map` → `/home/aw/autoware_map`).

## Why

The Docker installation guide was telling users to run shell scripts that no longer exist, breaking the documented happy path for both new users and developers. Anchoring this side to upstream READMEs keeps the docs accurate without duplicating content that drifts every time the Docker pipeline changes.

---

## Test plan

From the repository root:

```bash
mkdocs build --strict 2>&1 | grep -iE 'docker-installation|core-docker|troubleshoot|awsim' && echo "BAD: warnings touch changed files" || echo "OK: no warnings on changed files"
grep -rnE 'docker/run\.sh|docker/build\.sh' docs/ && echo "BAD: stale script ref remains" || echo "OK: no stale script refs"
grep -rnE 'autoware-universe:latest|autoware:universe[^-]|autoware:core[^-]' docs/ && echo "BAD: stale image tag remains" || echo "OK: no stale image tags"
pre-commit run --files docs/installation/autoware/docker-installation.md docs/installation/autoware/core-docker-installation.md docs/community/support/troubleshooting/index.md docs/demos/digital-twin-demos/autoware-core-awsim/index.md
```

- [ ] `mkdocs build --strict` produces no new warnings on the four changed files. The eight pre-existing strict-mode warnings in `reference-design/get-started/build-examples.md` are unrelated to this PR.
- [ ] No `./docker/run.sh` or `./docker/build.sh` references remain anywhere under `docs/`.
- [ ] No untagged `autoware:core` / `autoware:universe` / `autoware-universe:latest` references remain.
- [ ] `pre-commit run` on the four files passes (markdownlint, prettier, trailing whitespace).
- [ ] On the rendered Docker installation page, the `Update the Workspace` heading is still present so the `#update-the-workspace` anchor stays valid — `community/support/troubleshooting/index.md#build-issues` deep-links into it.
- [ ] Every external link resolves: the upstream README anchors (`#image-graph`, `#images`, `#pull-from-ghcr`, `#usage`, `#build-locally`), the three `examples/demos/*` folders, `examples/basic/`, the GHCR packages page, and the two Open AD Kit URLs.
