### PR TITLE
docs: migrate map/data paths to ~/autoware_data/{maps,ml_models} layout

### DIFF
--- a/docs/demos/digital-twin-demos/autoware-core-awsim/index.md
+++ b/docs/demos/digital-twin-demos/autoware-core-awsim/index.md
@@ -62,13 +62,13 @@ If you have not yet installed Autoware, please refer to the [Installation](../..
 
    ```bash
    xhost +local:
-   docker run --rm -it --net host -e DISPLAY=$DISPLAY -v $HOME/Downloads/Shinjuku-Map/map:/home/aw/autoware_map ghcr.io/autowarefoundation/autoware:core-humble
+   docker run --rm -it --net host -e DISPLAY=$DISPLAY -v $HOME/Downloads/Shinjuku-Map/map:/home/aw/autoware_data/maps ghcr.io/autowarefoundation/autoware:core-humble
    ```
 
 2. Run the following command in the docker container.
 
    ```bash
-   ros2 launch autoware_core autoware_core.launch.xml use_sim_time:=true map_path:=/home/aw/autoware_map vehicle_model:=autoware_sample_vehicle sensor_model:=autoware_awsim_sensor_kit
+   ros2 launch autoware_core autoware_core.launch.xml use_sim_time:=true map_path:=/home/aw/autoware_data/maps vehicle_model:=autoware_sample_vehicle sensor_model:=autoware_awsim_sensor_kit
    ```
 
 ## Launch Autoware for source installation

--- a/docs/demos/digital-twin-demos/carla-tutorial.md
+++ b/docs/demos/digital-twin-demos/carla-tutorial.md
@@ -22,13 +22,13 @@ TensorRT-optimized Vectorized Autonomous Driving ([VAD](https://github.com/hustv
 - Usage (CARLA E2E mode):
   1. Build the package and deps: `colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --packages-up-to autoware_tensorrt_vad`.
   2. Prepare CARLA following `autoware_carla_interface` (use `carla_sensor_kit` so camera topics match the VAD training order: FRONT, BACK, FRONT_LEFT, BACK_LEFT, FRONT_RIGHT, BACK_RIGHT).
-  3. Ensure VAD models are downloaded (default to `~/autoware_data/vad` via the Autoware setup script).
+  3. Ensure VAD models are downloaded (default to `~/autoware_data/ml_models/vad` via the Autoware setup script).
   4. Start CARLA server (example headless/GPU-friendly): `./CarlaUE4.sh -prefernvidia -quality-level=Low -RenderOffScreen`.
   5. Launch Autoware in E2E mode:
 
      ```bash
      ros2 launch autoware_launch e2e_simulator.launch.xml \
-       map_path:=$HOME/autoware_map/Town01 \
+       map_path:=$HOME/autoware_data/maps/Town01 \
        vehicle_model:=sample_vehicle \
        sensor_model:=carla_sensor_kit \
        simulator_type:=carla \

--- a/docs/demos/planning-sim/index.md
+++ b/docs/demos/planning-sim/index.md
@@ -4,7 +4,7 @@
 
 ### Download the sample map
 
-Use the [`demo_artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/demo_artifacts) ansible role to download and extract the sample map into `~/autoware_data/maps/demos/sample-map-planning/`:
+Use the [`demo_artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/demo_artifacts) ansible role to download and extract the sample map into `~/autoware_data/maps/sample-map-planning/`:
 
 ```bash
 ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
@@ -39,7 +39,7 @@ If not, please, follow [Manual downloading of artifacts](https://github.com/auto
 
 ```bash
 source ~/autoware/install/setup.bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/demos/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
 ```
 
 !!! warning

--- a/docs/demos/planning-sim/index.md
+++ b/docs/demos/planning-sim/index.md
@@ -4,26 +4,12 @@
 
 ### Download the sample map
 
-The recommended way is to use the [`demo_artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/demo_artifacts) ansible role, which downloads and extracts the sample map (and the rosbag-replay demo assets) into the standard layout under `~/autoware_data/`:
+Use the [`demo_artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/demo_artifacts) ansible role to download and extract the sample map into `~/autoware_data/maps/demos/sample-map-planning/`:
 
 ```bash
 ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
 ansible-playbook autoware.dev_env.install_dev_env --tags demo_artifacts --ask-become-pass
 ```
-
-After running the role, the sample map is available at `~/autoware_data/maps/demos/sample-map-planning/`.
-
-??? note "Manual download"
-
-    If you cannot run ansible, download and unpack the map manually:
-
-    ```bash
-    mkdir -p ~/autoware_data/maps/demos
-    gdown -O ~/autoware_data/maps/demos/ 'https://docs.google.com/uc?export=download&id=1499_nsbUbIeturZaDj7jhUownh5fvXHd'
-    unzip -d ~/autoware_data/maps/demos ~/autoware_data/maps/demos/sample-map-planning.zip
-    ```
-
-    You can also download [the map](https://drive.google.com/file/d/1499_nsbUbIeturZaDj7jhUownh5fvXHd/view?usp=sharing) manually from the browser.
 
 !!! info
 

--- a/docs/demos/planning-sim/index.md
+++ b/docs/demos/planning-sim/index.md
@@ -4,23 +4,37 @@
 
 ### Download the sample map
 
+The recommended way is to use the [`demo_artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/demo_artifacts) ansible role, which downloads and extracts the sample map (and the rosbag-replay demo assets) into the standard layout under `~/autoware_data/`:
+
 ```bash
-gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=1499_nsbUbIeturZaDj7jhUownh5fvXHd'
-unzip -d ~/autoware_map ~/autoware_map/sample-map-planning.zip
+ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
+ansible-playbook autoware.dev_env.install_dev_env --tags demo_artifacts --ask-become-pass
 ```
 
-- You can also download [the map](https://drive.google.com/file/d/1499_nsbUbIeturZaDj7jhUownh5fvXHd/view?usp=sharing) manually.
+After running the role, the sample map is available at `~/autoware_data/maps/demos/sample-map-planning/`.
+
+??? note "Manual download"
+
+    If you cannot run ansible, download and unpack the map manually:
+
+    ```bash
+    mkdir -p ~/autoware_data/maps/demos
+    gdown -O ~/autoware_data/maps/demos/ 'https://docs.google.com/uc?export=download&id=1499_nsbUbIeturZaDj7jhUownh5fvXHd'
+    unzip -d ~/autoware_data/maps/demos ~/autoware_data/maps/demos/sample-map-planning.zip
+    ```
+
+    You can also download [the map](https://drive.google.com/file/d/1499_nsbUbIeturZaDj7jhUownh5fvXHd/view?usp=sharing) manually from the browser.
 
 !!! info
 
     Sample map: Copyright 2020 TIER IV, Inc.
 
-### Make sure the artifacts are downloaded
+### Make sure the ML model artifacts are downloaded
 
-Check if you have `~/autoware_data` folder and files in it.
+Check if you have `~/autoware_data/ml_models` folder and files in it.
 
 ```bash
-$ cd ~/autoware_data
+$ cd ~/autoware_data/ml_models
 $ ls -C -w 30
 image_projection_based_fusion
 lidar_apollo_instance_segmentation
@@ -39,7 +53,7 @@ If not, please, follow [Manual downloading of artifacts](https://github.com/auto
 
 ```bash
 source ~/autoware/install/setup.bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/demos/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
 ```
 
 !!! warning

--- a/docs/demos/planning-sim/lane-change.md
+++ b/docs/demos/planning-sim/lane-change.md
@@ -3,15 +3,16 @@
 1. Download and unpack Nishishinjuku map.
 
    ```bash
-   gdown -O ~/autoware_map/ 'https://github.com/tier4/AWSIM/releases/download/v1.1.0/nishishinjuku_autoware_map.zip'
-   unzip -d ~/autoware_map ~/autoware_map/nishishinjuku_autoware_map.zip
+   mkdir -p ~/autoware_data/maps
+   gdown -O ~/autoware_data/maps/ 'https://github.com/tier4/AWSIM/releases/download/v1.1.0/nishishinjuku_autoware_map.zip'
+   unzip -d ~/autoware_data/maps ~/autoware_data/maps/nishishinjuku_autoware_map.zip
    ```
 
 2. Launch autoware with Nishishinjuku map with following command:
 
    ```bash
    source ~/autoware/install/setup.bash
-   ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/nishishinjuku_autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+   ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/nishishinjuku_autoware_map vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
    ```
 
    ![open-nishishinjuku-map](images/lane-change/open-nishishinjuku-map.png)

--- a/docs/demos/planning-sim/lane-driving.md
+++ b/docs/demos/planning-sim/lane-driving.md
@@ -4,7 +4,7 @@
 
 ```bash
 source ~/autoware/install/setup.bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/demos/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
 ```
 
 !!! warning

--- a/docs/demos/planning-sim/lane-driving.md
+++ b/docs/demos/planning-sim/lane-driving.md
@@ -4,7 +4,7 @@
 
 ```bash
 source ~/autoware/install/setup.bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/demos/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
 ```
 
 !!! warning

--- a/docs/demos/rosbag-replay-simulation.md
+++ b/docs/demos/rosbag-replay-simulation.md
@@ -2,26 +2,44 @@
 
 ## Preparation
 
-1. Download and unpack a sample map.
-   - You can also download [the map](https://drive.google.com/file/d/1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI/view?usp=sharing) manually.
+1. Download and unpack the sample map and rosbag.
+
+   The recommended way is to use the [`demo_artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/demo_artifacts) ansible role, which fetches and extracts both the sample map and the sample rosbag into the standard layout under `~/autoware_data/`:
 
    ```bash
-   gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI'
-   unzip -d ~/autoware_map/ ~/autoware_map/sample-map-rosbag.zip
+   ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
+   ansible-playbook autoware.dev_env.install_dev_env --tags demo_artifacts --ask-become-pass
    ```
 
-2. Download the sample rosbag files.
-   - You can also download [the rosbag files](https://drive.google.com/file/d/1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP/view?usp=sharing) manually.
+   After running the role:
+
+   - sample map → `~/autoware_data/maps/demos/sample-map-rosbag/`
+   - sample rosbag → `~/autoware_data/recordings/bags/demos/sample-rosbag/`
+
+   ??? note "Manual download"
+
+       If you cannot run ansible, download and unpack the assets manually.
+
+       Sample map ([direct download](https://drive.google.com/file/d/1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI/view?usp=sharing)):
+
+       ```bash
+       mkdir -p ~/autoware_data/maps/demos
+       gdown -O ~/autoware_data/maps/demos/ 'https://docs.google.com/uc?export=download&id=1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI'
+       unzip -d ~/autoware_data/maps/demos/ ~/autoware_data/maps/demos/sample-map-rosbag.zip
+       ```
+
+       Sample rosbag ([direct download](https://drive.google.com/file/d/1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP/view?usp=sharing)):
+
+       ```bash
+       mkdir -p ~/autoware_data/recordings/bags/demos
+       gdown -O ~/autoware_data/recordings/bags/demos/ 'https://docs.google.com/uc?export=download&id=1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP'
+       unzip -d ~/autoware_data/recordings/bags/demos/ ~/autoware_data/recordings/bags/demos/sample-rosbag.zip
+       ```
+
+2. Check if you have `~/autoware_data/ml_models` folder and files in it.
 
    ```bash
-   gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP'
-   unzip -d ~/autoware_map/ ~/autoware_map/sample-rosbag.zip
-   ```
-
-3. Check if you have `~/autoware_data` folder and files in it.
-
-   ```bash
-   $ cd ~/autoware_data
+   $ cd ~/autoware_data/ml_models
    $ ls -C -w 30
    image_projection_based_fusion
    lidar_apollo_instance_segmentation
@@ -53,7 +71,7 @@
 
    ```sh
    source ~/autoware/install/setup.bash
-   ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_map/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+   ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_data/maps/demos/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
    ```
 
    Note that you cannot use `~` instead of `$HOME` here.
@@ -66,7 +84,7 @@
 
    ```sh
    source ~/autoware/install/setup.bash
-   ros2 bag play ~/autoware_map/sample-rosbag/ -r 0.2 -s sqlite3
+   ros2 bag play ~/autoware_data/recordings/bags/demos/sample-rosbag/ -r 0.2 -s sqlite3
    ```
 
    > ⚠️ Due to the discrepancy between the timestamp in the `rosbag` and the current system timestamp, Autoware may generate warning messages in the terminal alerting to this mismatch. This is normal behavior.

--- a/docs/demos/rosbag-replay-simulation.md
+++ b/docs/demos/rosbag-replay-simulation.md
@@ -2,57 +2,56 @@
 
 ## Preparation
 
-1. Download and unpack the sample map and rosbag.
+1.  Download and unpack the sample map and rosbag.
 
-   The recommended way is to use the [`demo_artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/demo_artifacts) ansible role, which fetches and extracts both the sample map and the sample rosbag into the standard layout under `~/autoware_data/`:
+    The recommended way is to use the [`demo_artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/demo_artifacts) ansible role, which fetches and extracts both the sample map and the sample rosbag into the standard layout under `~/autoware_data/`:
 
-   ```bash
-   ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
-   ansible-playbook autoware.dev_env.install_dev_env --tags demo_artifacts --ask-become-pass
-   ```
+    ```bash
+    ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
+    ansible-playbook autoware.dev_env.install_dev_env --tags demo_artifacts --ask-become-pass
+    ```
 
-   After running the role:
+    After running the role:
+    - sample map → `~/autoware_data/maps/demos/sample-map-rosbag/`
+    - sample rosbag → `~/autoware_data/recordings/bags/demos/sample-rosbag/`
 
-   - sample map → `~/autoware_data/maps/demos/sample-map-rosbag/`
-   - sample rosbag → `~/autoware_data/recordings/bags/demos/sample-rosbag/`
+    ??? note "Manual download"
 
-   ??? note "Manual download"
+        If you cannot run ansible, download and unpack the assets manually.
 
-       If you cannot run ansible, download and unpack the assets manually.
+        Sample map ([direct download](https://drive.google.com/file/d/1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI/view?usp=sharing)):
 
-       Sample map ([direct download](https://drive.google.com/file/d/1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI/view?usp=sharing)):
+        ```bash
+        mkdir -p ~/autoware_data/maps/demos
+        gdown -O ~/autoware_data/maps/demos/ 'https://docs.google.com/uc?export=download&id=1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI'
+        unzip -d ~/autoware_data/maps/demos/ ~/autoware_data/maps/demos/sample-map-rosbag.zip
+        ```
 
-       ```bash
-       mkdir -p ~/autoware_data/maps/demos
-       gdown -O ~/autoware_data/maps/demos/ 'https://docs.google.com/uc?export=download&id=1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI'
-       unzip -d ~/autoware_data/maps/demos/ ~/autoware_data/maps/demos/sample-map-rosbag.zip
-       ```
+        Sample rosbag ([direct download](https://drive.google.com/file/d/1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP/view?usp=sharing)):
 
-       Sample rosbag ([direct download](https://drive.google.com/file/d/1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP/view?usp=sharing)):
+        ```bash
+        mkdir -p ~/autoware_data/recordings/bags/demos
+        gdown -O ~/autoware_data/recordings/bags/demos/ 'https://docs.google.com/uc?export=download&id=1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP'
+        unzip -d ~/autoware_data/recordings/bags/demos/ ~/autoware_data/recordings/bags/demos/sample-rosbag.zip
+        ```
 
-       ```bash
-       mkdir -p ~/autoware_data/recordings/bags/demos
-       gdown -O ~/autoware_data/recordings/bags/demos/ 'https://docs.google.com/uc?export=download&id=1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP'
-       unzip -d ~/autoware_data/recordings/bags/demos/ ~/autoware_data/recordings/bags/demos/sample-rosbag.zip
-       ```
+2.  Check if you have `~/autoware_data/ml_models` folder and files in it.
 
-2. Check if you have `~/autoware_data/ml_models` folder and files in it.
+    ```bash
+    $ cd ~/autoware_data/ml_models
+    $ ls -C -w 30
+    image_projection_based_fusion
+    lidar_apollo_instance_segmentation
+    lidar_centerpoint
+    tensorrt_yolo
+    tensorrt_yolox
+    traffic_light_classifier
+    traffic_light_fine_detector
+    traffic_light_ssd_fine_detector
+    yabloc_pose_initializer
+    ```
 
-   ```bash
-   $ cd ~/autoware_data/ml_models
-   $ ls -C -w 30
-   image_projection_based_fusion
-   lidar_apollo_instance_segmentation
-   lidar_centerpoint
-   tensorrt_yolo
-   tensorrt_yolox
-   traffic_light_classifier
-   traffic_light_fine_detector
-   traffic_light_ssd_fine_detector
-   yabloc_pose_initializer
-   ```
-
-   If not, please, follow [Manual downloading of artifacts](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts).
+    If not, please, follow [Manual downloading of artifacts](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts).
 
 !!! info
 

--- a/docs/demos/rosbag-replay-simulation.md
+++ b/docs/demos/rosbag-replay-simulation.md
@@ -2,56 +2,59 @@
 
 ## Preparation
 
-1.  Download and unpack the sample map and rosbag.
+### Download the sample map and rosbag
 
-    The recommended way is to use the [`demo_artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/demo_artifacts) ansible role, which fetches and extracts both the sample map and the sample rosbag into the standard layout under `~/autoware_data/`:
+The recommended way is to use the [`demo_artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/demo_artifacts) ansible role, which fetches and extracts both the sample map and the sample rosbag into the standard layout under `~/autoware_data/`:
 
-    ```bash
-    ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
-    ansible-playbook autoware.dev_env.install_dev_env --tags demo_artifacts --ask-become-pass
-    ```
+```bash
+ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
+ansible-playbook autoware.dev_env.install_dev_env --tags demo_artifacts --ask-become-pass
+```
 
-    After running the role:
-    - sample map → `~/autoware_data/maps/demos/sample-map-rosbag/`
-    - sample rosbag → `~/autoware_data/recordings/bags/demos/sample-rosbag/`
+After running the role:
 
-    ??? note "Manual download"
+- sample map → `~/autoware_data/maps/demos/sample-map-rosbag/`
+- sample rosbag → `~/autoware_data/recordings/bags/demos/sample-rosbag/`
 
-        If you cannot run ansible, download and unpack the assets manually.
+??? note "Manual download"
 
-        Sample map ([direct download](https://drive.google.com/file/d/1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI/view?usp=sharing)):
+    If you cannot run ansible, download and unpack the assets manually.
 
-        ```bash
-        mkdir -p ~/autoware_data/maps/demos
-        gdown -O ~/autoware_data/maps/demos/ 'https://docs.google.com/uc?export=download&id=1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI'
-        unzip -d ~/autoware_data/maps/demos/ ~/autoware_data/maps/demos/sample-map-rosbag.zip
-        ```
-
-        Sample rosbag ([direct download](https://drive.google.com/file/d/1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP/view?usp=sharing)):
-
-        ```bash
-        mkdir -p ~/autoware_data/recordings/bags/demos
-        gdown -O ~/autoware_data/recordings/bags/demos/ 'https://docs.google.com/uc?export=download&id=1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP'
-        unzip -d ~/autoware_data/recordings/bags/demos/ ~/autoware_data/recordings/bags/demos/sample-rosbag.zip
-        ```
-
-2.  Check if you have `~/autoware_data/ml_models` folder and files in it.
+    Sample map ([direct download](https://drive.google.com/file/d/1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI/view?usp=sharing)):
 
     ```bash
-    $ cd ~/autoware_data/ml_models
-    $ ls -C -w 30
-    image_projection_based_fusion
-    lidar_apollo_instance_segmentation
-    lidar_centerpoint
-    tensorrt_yolo
-    tensorrt_yolox
-    traffic_light_classifier
-    traffic_light_fine_detector
-    traffic_light_ssd_fine_detector
-    yabloc_pose_initializer
+    mkdir -p ~/autoware_data/maps/demos
+    gdown -O ~/autoware_data/maps/demos/ 'https://docs.google.com/uc?export=download&id=1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI'
+    unzip -d ~/autoware_data/maps/demos/ ~/autoware_data/maps/demos/sample-map-rosbag.zip
     ```
 
-    If not, please, follow [Manual downloading of artifacts](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts).
+    Sample rosbag ([direct download](https://drive.google.com/file/d/1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP/view?usp=sharing)):
+
+    ```bash
+    mkdir -p ~/autoware_data/recordings/bags/demos
+    gdown -O ~/autoware_data/recordings/bags/demos/ 'https://docs.google.com/uc?export=download&id=1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP'
+    unzip -d ~/autoware_data/recordings/bags/demos/ ~/autoware_data/recordings/bags/demos/sample-rosbag.zip
+    ```
+
+### Make sure the ML model artifacts are downloaded
+
+Check if you have `~/autoware_data/ml_models` folder and files in it.
+
+```bash
+$ cd ~/autoware_data/ml_models
+$ ls -C -w 30
+image_projection_based_fusion
+lidar_apollo_instance_segmentation
+lidar_centerpoint
+tensorrt_yolo
+tensorrt_yolox
+traffic_light_classifier
+traffic_light_fine_detector
+traffic_light_ssd_fine_detector
+yabloc_pose_initializer
+```
+
+If not, please, follow [Manual downloading of artifacts](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts).
 
 !!! info
 

--- a/docs/demos/rosbag-replay-simulation.md
+++ b/docs/demos/rosbag-replay-simulation.md
@@ -13,8 +13,8 @@ ansible-playbook autoware.dev_env.install_dev_env --tags demo_artifacts --ask-be
 
 After running the role:
 
-- sample map → `~/autoware_data/maps/demos/sample-map-rosbag/`
-- sample rosbag → `~/autoware_data/recordings/bags/demos/sample-rosbag/`
+- sample map → `~/autoware_data/maps/sample-map-rosbag/`
+- sample rosbag → `~/autoware_data/recordings/bags/sample-rosbag/`
 
 ### Make sure the ML model artifacts are downloaded
 
@@ -53,7 +53,7 @@ If not, please, follow [Manual downloading of artifacts](https://github.com/auto
 
    ```sh
    source ~/autoware/install/setup.bash
-   ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_data/maps/demos/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
+   ros2 launch autoware_launch logging_simulator.launch.xml map_path:=$HOME/autoware_data/maps/sample-map-rosbag vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
    ```
 
    Note that you cannot use `~` instead of `$HOME` here.
@@ -66,7 +66,7 @@ If not, please, follow [Manual downloading of artifacts](https://github.com/auto
 
    ```sh
    source ~/autoware/install/setup.bash
-   ros2 bag play ~/autoware_data/recordings/bags/demos/sample-rosbag/ -r 0.2 -s sqlite3
+   ros2 bag play ~/autoware_data/recordings/bags/sample-rosbag/ -r 0.2 -s sqlite3
    ```
 
    > ⚠️ Due to the discrepancy between the timestamp in the `rosbag` and the current system timestamp, Autoware may generate warning messages in the terminal alerting to this mismatch. This is normal behavior.

--- a/docs/demos/rosbag-replay-simulation.md
+++ b/docs/demos/rosbag-replay-simulation.md
@@ -4,7 +4,7 @@
 
 ### Download the sample map and rosbag
 
-The recommended way is to use the [`demo_artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/demo_artifacts) ansible role, which fetches and extracts both the sample map and the sample rosbag into the standard layout under `~/autoware_data/`:
+Use the [`demo_artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/demo_artifacts) ansible role to download and extract both the sample map and the sample rosbag:
 
 ```bash
 ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
@@ -15,26 +15,6 @@ After running the role:
 
 - sample map → `~/autoware_data/maps/demos/sample-map-rosbag/`
 - sample rosbag → `~/autoware_data/recordings/bags/demos/sample-rosbag/`
-
-??? note "Manual download"
-
-    If you cannot run ansible, download and unpack the assets manually.
-
-    Sample map ([direct download](https://drive.google.com/file/d/1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI/view?usp=sharing)):
-
-    ```bash
-    mkdir -p ~/autoware_data/maps/demos
-    gdown -O ~/autoware_data/maps/demos/ 'https://docs.google.com/uc?export=download&id=1A-8BvYRX3DhSzkAnOcGWFw5T30xTlwZI'
-    unzip -d ~/autoware_data/maps/demos/ ~/autoware_data/maps/demos/sample-map-rosbag.zip
-    ```
-
-    Sample rosbag ([direct download](https://drive.google.com/file/d/1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP/view?usp=sharing)):
-
-    ```bash
-    mkdir -p ~/autoware_data/recordings/bags/demos
-    gdown -O ~/autoware_data/recordings/bags/demos/ 'https://docs.google.com/uc?export=download&id=1sU5wbxlXAfHIksuHjP3PyI2UVED8lZkP'
-    unzip -d ~/autoware_data/recordings/bags/demos/ ~/autoware_data/recordings/bags/demos/sample-rosbag.zip
-    ```
 
 ### Make sure the ML model artifacts are downloaded
 

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -89,7 +89,7 @@ Open AD Kit provides different deployment options for Autoware, so that you can 
 
 ## Development
 
-For developing against Autoware (rather than just running it), the [`docker/examples/basic/`](https://github.com/autowarefoundation/autoware/tree/main/docker/examples/basic) folder ships three Compose files — each a "drop me into a shell" container built on the `universe-devel-*` images, with `~/autoware_map`, `~/autoware_data`, and the autoware source tree mounted. Pick the flavor that matches your host:
+For developing against Autoware (rather than just running it), the [`docker/examples/basic/`](https://github.com/autowarefoundation/autoware/tree/main/docker/examples/basic) folder ships three Compose files — each a "drop me into a shell" container built on the `universe-devel-*` images, with `~/autoware_data` (containing `maps/` and `ml_models/`) and the autoware source tree mounted. Pick the flavor that matches your host:
 
 | Host GPU / driver            | Compose file                                |
 | ---------------------------- | ------------------------------------------- |

--- a/docs/tutorials/integrating-autoware/creating-maps/creating-vector-map/crosswalk/index.md
+++ b/docs/tutorials/integrating-autoware/creating-maps/creating-vector-map/crosswalk/index.md
@@ -51,7 +51,7 @@ ros2 launch autoware_launch planning_simulator.launch.xml map_path:=<YOUR-MAP-FO
 Example for tutorial_vehicle:
 
 ```bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/Files/autoware_map/tutorial_map/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/tutorial_map/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
 ```
 
 1. Click `2D Pose Estimate` button on rviz or press `P` and give a pose for initialization.

--- a/docs/tutorials/integrating-autoware/creating-maps/creating-vector-map/detection-area/index.md
+++ b/docs/tutorials/integrating-autoware/creating-maps/creating-vector-map/detection-area/index.md
@@ -53,7 +53,7 @@ ros2 launch autoware_launch planning_simulator.launch.xml map_path:=<YOUR-MAP-FO
 Example for tutorial_vehicle:
 
 ```bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/Files/autoware_map/tutorial_map/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/tutorial_map/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
 ```
 
 1. Click `2D Pose Estimate` button on rviz or press `P` and give a pose for initialization.

--- a/docs/tutorials/integrating-autoware/creating-maps/creating-vector-map/lanelet2/index.md
+++ b/docs/tutorials/integrating-autoware/creating-maps/creating-vector-map/lanelet2/index.md
@@ -114,7 +114,7 @@ ros2 launch autoware_launch planning_simulator.launch.xml map_path:=<YOUR-MAP-FO
 Example for tutorial_vehicle:
 
 ```bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/Files/autoware_map/tutorial_map/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/tutorial_map/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
 ```
 
 1. Click `2D Pose Estimate` button on rviz or press `P` and give a pose for initialization.

--- a/docs/tutorials/integrating-autoware/creating-maps/creating-vector-map/speed-bump/index.md
+++ b/docs/tutorials/integrating-autoware/creating-maps/creating-vector-map/speed-bump/index.md
@@ -61,7 +61,7 @@ ros2 launch autoware_launch planning_simulator.launch.xml map_path:=<YOUR-MAP-FO
 Example for tutorial_vehicle:
 
 ```bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/Files/autoware_map/tutorial_map/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/tutorial_map/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
 ```
 
 1. Click `2D Pose Estimate` button on rviz or press `P` and give a pose for initialization.

--- a/docs/tutorials/integrating-autoware/creating-maps/creating-vector-map/stop-line/index.md
+++ b/docs/tutorials/integrating-autoware/creating-maps/creating-vector-map/stop-line/index.md
@@ -52,7 +52,7 @@ ros2 launch autoware_launch planning_simulator.launch.xml map_path:=<YOUR-MAP-FO
 Example for tutorial_vehicle:
 
 ```bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/Files/autoware_map/tutorial_map/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/tutorial_map/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
 ```
 
 1. Click `2D Pose Estimate` button on rviz or press `P` and give a pose for initialization.

--- a/docs/tutorials/integrating-autoware/creating-maps/creating-vector-map/traffic-light/index.md
+++ b/docs/tutorials/integrating-autoware/creating-maps/creating-vector-map/traffic-light/index.md
@@ -52,7 +52,7 @@ ros2 launch autoware_launch planning_simulator.launch.xml map_path:=<YOUR-MAP-FO
 Example for tutorial_vehicle:
 
 ```bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/Files/autoware_map/tutorial_map/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/tutorial_map/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
 ```
 
 1. Click `2D Pose Estimate` button on rviz or press `P` and give a pose for initialization.

--- a/docs/tutorials/integrating-autoware/creating-vehicle-and-sensor-model/creating-vehicle-model/index.md
+++ b/docs/tutorials/integrating-autoware/creating-vehicle-and-sensor-model/creating-vehicle-model/index.md
@@ -256,13 +256,13 @@ source the install/setup.bash file in your Autoware project folder
 and run this command in your terminal:
 
 ```bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/Files/autoware_map/sample-map-planning/ vehicle_model:=<YOUR-VEHICLE-MODEL> sensor_model:=<YOUR-SENSOR-KIT> vehicle_id:=<YOUR-VEHICLE-ID>
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/sample-map-planning/ vehicle_model:=<YOUR-VEHICLE-MODEL> sensor_model:=<YOUR-SENSOR-KIT> vehicle_id:=<YOUR-VEHICLE-ID>
 ```
 
 For example, if we try planning simulator with the tutorial_vehicle:
 
 ```bash
-ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/Files/autoware_map/sample-map-planning/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
+ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/sample-map-planning/ vehicle_model:=tutorial_vehicle sensor_model:=tutorial_vehicle_sensor_kit vehicle_id:=tutorial_vehicle
 ```
 
 The planning simulator will open, and you can give an initial pose to your vehicle

--- a/docs/tutorials/integrating-autoware/creating-vehicle-interface-package/creating-vehicle-interface.md
+++ b/docs/tutorials/integrating-autoware/creating-vehicle-interface-package/creating-vehicle-interface.md
@@ -222,7 +222,7 @@ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --package
 Finally, you are done implementing your vehicle interface module! Be careful that you need to launch Autoware with the proper `vehicle_model` option like the example below. This example is launching planning simulator.
 
 ```bash
-ros2 launch autoware_launch planning.launch.xml map_path:=$HOME/autoware_map/sample-map-planning vehicle_model:=<YOUR-VEHICLE-NAME> sensor_model:=<YOUR-VEHICLE-NAME>_sensor_kit
+ros2 launch autoware_launch planning.launch.xml map_path:=$HOME/autoware_data/maps/sample-map-planning vehicle_model:=<YOUR-VEHICLE-NAME> sensor_model:=<YOUR-VEHICLE-NAME>_sensor_kit
 ```
 
 ### Tips

--- a/docs/tutorials/integrating-autoware/launch-autoware/index.md
+++ b/docs/tutorials/integrating-autoware/launch-autoware/index.md
@@ -133,17 +133,17 @@ you will need to update these map file name arguments:
 
 ### Perception
 
-You can define your `autoware_data` path here.
+You can define your `autoware_data/ml_models` path here.
 Autoware gets yabloc_pose_initializer,
 image_projection_based_fusion,
-lidar_apollo_instance_segmentation etc. models file with `autoware_data` path.
+lidar_apollo_instance_segmentation etc. models file with `data_path`.
 If you use ansible for autoware installation,
-the necessary artifacts will be downloaded at `autoware_data` folder on your `$HOME` directory.
+the necessary artifacts will be downloaded at the `autoware_data/ml_models` folder on your `$HOME` directory.
 If you want to download artifacts manually,
 please check ansible [`artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/artifacts) page for information.
 
 ```diff
-- <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
+- <arg name="data_path" default="$(env HOME)/autoware_data/ml_models" description="packages data and artifacts directory path"/>
 + <arg name="data_path" default="<YOUR-AUTOWARE-DATA-PATH>" description="packages data and artifacts directory path"/>
 ```
 

--- a/docs/tutorials/others/using-divided-map.md
+++ b/docs/tutorials/others/using-divided-map.md
@@ -4,11 +4,12 @@ Divided pointcloud map is necessary when handling large pointcloud map, in which
 
 ## Tutorial
 
-Download the [sample-map-rosbag_split](https://docs.google.com/uc?export=download&id=11tLC9T4MS8fnZ9Wo0D8-Ext7hEDl2YJ4) and locate the map under `$HOME/autoware_map/`.
+Download the [sample-map-rosbag_split](https://docs.google.com/uc?export=download&id=11tLC9T4MS8fnZ9Wo0D8-Ext7hEDl2YJ4) and locate the map under `$HOME/autoware_data/maps/`.
 
 ```bash
-gdown -O ~/autoware_map/ 'https://docs.google.com/uc?export=download&id=11tLC9T4MS8fnZ9Wo0D8-Ext7hEDl2YJ4'
-unzip -d ~/autoware_map/ ~/autoware_map/sample-rosbag_split.zip
+mkdir -p ~/autoware_data/maps
+gdown -O ~/autoware_data/maps/ 'https://docs.google.com/uc?export=download&id=11tLC9T4MS8fnZ9Wo0D8-Ext7hEDl2YJ4'
+unzip -d ~/autoware_data/maps/ ~/autoware_data/maps/sample-rosbag_split.zip
 ```
 
 Then, you may launch logging_simulator with the following command to load the divided map.
@@ -17,7 +18,7 @@ Note that you need to specify the `map_path` and `pointcloud_map_file` arguments
 ```bash
 source ~/autoware/install/setup.bash
 ros2 launch autoware_launch logging_simulator.launch.xml \
-  map_path:=$HOME/autoware_map/sample-map-rosbag pointcloud_map_file:=pointcloud_map \
+  map_path:=$HOME/autoware_data/maps/sample-map-rosbag pointcloud_map_file:=pointcloud_map \
   vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
 ```
 


### PR DESCRIPTION
- Parent Issue: https://github.com/autowarefoundation/autoware/issues/7068
- Sweeps 17 files across demos, installation, and integration tutorials so that every `~/autoware_map/...`, `~/autoware_data/<model>`, and in-container `/home/aw/autoware_map` reference uses the new unified layout: ML models under `~/autoware_data/ml_models/`, maps under `~/autoware_data/maps/`, rosbag recordings under `~/autoware_data/recordings/bags/`.
- For the two officially-supported demos (planning sim, rosbag replay), promotes the new [`demo_artifacts`](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/demo_artifacts) ansible role as the way to fetch sample assets.

## Why

The legacy split layout (`~/autoware_data` for ML models, `~/autoware_map` for maps) is being consolidated upstream so that a single Docker bind / ansible run / volume mount covers all of Autoware's data. As soon as the five open upstream PRs land, this docs site will instruct users to put files in directories that no longer match defaults shipped by `autoware_launch`, `autoware_universe`, the ansible roles, and the demo Compose files. This PR keeps the documentation in lock-step with that migration and makes the new `demo_artifacts` role the path of least resistance for new users.

---

Depends on (should land after, for end-to-end coherence):

- https://github.com/autowarefoundation/autoware/pull/7077
- https://github.com/autowarefoundation/autoware_launch/pull/1835
- https://github.com/autowarefoundation/autoware_universe/pull/12523
- https://github.com/autowarefoundation/autoware_tools/pull/417
- https://github.com/autowarefoundation/autoware_system_designer/pull/53

The `converting-utm-to-mgrs-map` tutorial is intentionally not touched — its `/home/melike/projects/autoware_data/...` is a developer-specific project path being replaced with a `<PATH-TO-YOUR-...>` placeholder anyway, unrelated to `~/autoware_data`.

## Test plan

- [ ] **No legacy path strings remain in user-facing instructions.** All hits below should be either ROS package names (`autoware_map_loader`, `autoware_map_msgs`, `autoware_map_based_prediction`, …), the `nishishinjuku_autoware_map.zip` filename / extracted dir name, or the deliberately-untouched developer path placeholder in the UTM→MGRS map tutorial.

  ```bash
  grep -rn 'autoware_map' docs/
  grep -rn 'autoware_data' docs/
  ```

- [ ] **mkdocs renders without warnings and the affected pages look right.**

  ```bash
  python3 -m pip install -U $(curl -fsSL https://raw.githubusercontent.com/autowarefoundation/autoware-github-actions/main/deploy-docs/mkdocs-requirements.txt)
  mkdocs serve
  ```

  Click through and confirm code blocks + prose render correctly:
  - [ ] [`docs/demos/planning-sim/index.md`](https://github.com/autowarefoundation/autoware-documentation/blob/fe42ff08395bd2853d2c65bc4b7f2f287a4ef8db/docs/demos/planning-sim/index.md) — `demo_artifacts` block renders, sample map path is `~/autoware_data/maps/sample-map-planning/`.
  - [ ] [`docs/demos/rosbag-replay-simulation.md`](https://github.com/autowarefoundation/autoware-documentation/blob/fe42ff08395bd2853d2c65bc4b7f2f287a4ef8db/docs/demos/rosbag-replay-simulation.md) — `ros2 bag play ~/autoware_data/recordings/bags/sample-rosbag/` shown.
  - [ ] [`docs/demos/digital-twin-demos/autoware-core-awsim/index.md`](https://github.com/autowarefoundation/autoware-documentation/blob/fe42ff08395bd2853d2c65bc4b7f2f287a4ef8db/docs/demos/digital-twin-demos/autoware-core-awsim/index.md) — Docker bind target is `/home/aw/autoware_data/maps`.
  - [ ] [`docs/installation/autoware/docker-installation.md`](https://github.com/autowarefoundation/autoware-documentation/blob/fe42ff08395bd2853d2c65bc4b7f2f287a4ef8db/docs/installation/autoware/docker-installation.md) — Development section mentions `~/autoware_data` (with `maps/` and `ml_models/`), no separate `~/autoware_map`.
  - [ ] [`docs/tutorials/integrating-autoware/launch-autoware/index.md`](https://github.com/autowarefoundation/autoware-documentation/blob/fe42ff08395bd2853d2c65bc4b7f2f287a4ef8db/docs/tutorials/integrating-autoware/launch-autoware/index.md) — `data_path` default shows `$(env HOME)/autoware_data/ml_models`.

- [ ] **End-to-end smoke (after the upstream PRs merge):** run the planning-sim demo from a fresh checkout, executing the `demo_artifacts` ansible role from this PR's instructions, then verify the launch command opens RViz with the sample map loaded.

  ```bash
  ansible-galaxy collection install -f -r "ansible-galaxy-requirements.yaml"
  ansible-playbook autoware.dev_env.install_dev_env --tags demo_artifacts --ask-become-pass
  ls -d ~/autoware_data/maps/sample-map-planning
  ros2 launch autoware_launch planning_simulator.launch.xml map_path:=$HOME/autoware_data/maps/sample-map-planning vehicle_model:=sample_vehicle sensor_model:=sample_sensor_kit
  ```

- [ ] **`tag:deploy-docs` preview** — confirm the rendered preview link posted by the GitHub Actions bot.