### PR TITLE
docs: add information about stable release for 1.8.0

### DIFF
--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -15,6 +15,8 @@ The two images most users will care about:
 
 Replace `jazzy` with `humble` for ROS 2 Humble.
 
+These tags track the latest build. For a stable release, append the version to the tag — for example, `ghcr.io/autowarefoundation/autoware:universe-jazzy-1.8.0` for the `1.8.0` release on ROS 2 Jazzy.
+
 For the broader containerized-deployment story (deployment patterns, integrations, edge use cases), see Open AD Kit:
 
 - <https://github.com/autowarefoundation/openadkit>
@@ -36,6 +38,14 @@ For the broader containerized-deployment story (deployment patterns, integration
    git clone https://github.com/autowarefoundation/autoware.git
    cd autoware
    ```
+
+   By default, this checks out the `main` branch, which contains the latest in-development changes. If you want to use a stable release, check out the corresponding release tag (compatible with both ROS 2 Humble and Jazzy):
+
+   ```bash
+   git checkout 1.8.0
+   ```
+
+   The list of available tags can be found on the [autoware releases page](https://github.com/autowarefoundation/autoware/releases).
 
 2. Install Ansible and run the Docker setup playbook:
 

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -27,6 +27,14 @@ sudo apt-get -y install git
    cd autoware
    ```
 
+   By default, this checks out the `main` branch, which contains the latest in-development changes. If you want to use a stable release, check out the corresponding release tag. For example, to use the `1.8.0` release (compatible with both ROS 2 Humble and Jazzy):
+
+   ```bash
+   git checkout 1.8.0
+   ```
+
+   The list of available tags can be found on the [autoware releases page](https://github.com/autowarefoundation/autoware/releases).
+
 2. If you are installing Autoware for the first time, you can automatically install the dependencies by using the provided Ansible playbook.
 
    ```bash


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware/issues/7047

* Adds a note to the source installation guide explaining how to check out the 1.8.0 git tag for a stable release (compatible with both ROS 2 Humble and Jazzy).
* Adds the same git checkout 1.8.0 note to the Universe docker installation guide after the clone step.
* Adds a sentence in the docker image catalog section pointing users to versioned image tags like ghcr.io/autowarefoundation/autoware:universe-jazzy-1.8.0 for the stable release.

###Motivation
Users following the source/docker installation docs currently land on the main branch / latest image by default, with no signpost toward stable releases. This PR makes the stable path discoverable from the install guide itself.

## How was this PR tested?

Tested by the deploy-docs workflow.
