### PR TITLE
docs: add Autoware Core package inclusion criteria

### DIFF
--- a/docs/design/autoware-concepts/.pages
+++ b/docs/design/autoware-concepts/.pages
@@ -1,2 +1,3 @@
 nav:
   - index.md
+  - core-package-inclusion-criteria.md

--- a/docs/design/autoware-concepts/core-package-inclusion-criteria.md
+++ b/docs/design/autoware-concepts/core-package-inclusion-criteria.md
@@ -1,0 +1,48 @@
+# What belongs in Autoware Core
+
+[Autoware Core](https://github.com/autowarefoundation/autoware_core) is the stable, quality-assured base of the Autoware stack.
+This page explains what a package needs to live in Core, and how it gets there from Universe.
+
+## What Core stands for
+
+Core packages are the stable base of Autoware: they build, are tested, expose stable interfaces, and are maintained by the Autoware Foundation.
+Universe is the opposite: a place for experimentation, vendor-specific code, and fast-moving research.
+
+Adding a package to Core is a long-term commitment.
+It must stay tested, reviewed, and released for everyone who builds on Core.
+A package earns that place only by clearing the bar below.
+
+!!! note "The litmus test"
+
+    A package belongs in Core if you could hand it to a new user with no GPU, no vendor-specific stack, and no research models, and it would build, pass its tests, and speak only standardized interfaces.
+    And if enough of the ecosystem depends on it that the Foundation should guarantee its stability.
+    The one exception is shared GPU infrastructure, which lives in the optional CUDA layer described below.
+
+## Requirements
+
+A Core package must:
+
+- **Depend only downward.** No dependency on any Universe package, only on other Core packages, ROS via rosdep, and well-established third-party libraries. (Universe depends on Core, never the reverse; see the [repository structure](../repository-structure.md) diagram.)
+- **Use vendor-neutral interfaces.** No proprietary or company-namespaced packages (for example `tier4_*_msgs`). Communicate through the standard messages and `autoware_component_interface_specs`.
+- **Keep the default build CPU-only.** Standard Core packages need no GPU, CUDA, or TensorRT. GPU code belongs only in the optional CUDA layer described below, never mixed into the default packages.
+- **Be permissively licensed.** Apache 2.0 or compatible, with no restrictively licensed runtime dependency.
+- **Be tested and green.** Unit tests, the coverage gate, and the full Core CI passing on every supported distribution (currently Humble and Jazzy). Core enforces a stricter clang-tidy profile than Universe, so passing there is not enough.
+- **Be maintained.** Real maintainers, listed in `CODEOWNERS`, semantically versioned and released through Core.
+
+It should also be mature: a stable, documented interface, validated beyond unit tests (ideally on a vehicle), and broadly useful rather than tied to one vendor or one research project.
+
+## Getting into Core
+
+New work starts in Universe. A package is promoted once it clearly meets the bar above.
+
+Promotion is a deliberate port, not a copy: clean up dependencies, swap proprietary messages for standard ones, add tests.
+Move foundations first (messages, utilities, base layers) so packages built on them can follow without breaking.
+Package names do not change on promotion, so downstream code keeps working.
+
+## The CUDA layer
+
+Core ships in two forms: the default CPU-only packages, and an optional GPU layer, the `autoware_core_cuda` repository, built into separate CUDA images.
+A package that needs CUDA or TensorRT can still be Core, but only in this layer, so the default build never requires a GPU.
+
+The shared CUDA/TensorRT base (`autoware_tensorrt_common`, `autoware_tensorrt_plugins`, `autoware_cuda_utils`, `autoware_cuda_dependency_meta`) lives here.
+It is Core-quality: it depends only on these packages, Core tooling, ROS, and one external CMake module, with nothing from Universe, and many downstream GPU packages build on it.

--- a/docs/design/autoware-concepts/index.md
+++ b/docs/design/autoware-concepts/index.md
@@ -82,6 +82,7 @@ Universe acts as a **sandbox for experimentation**, allowing new ideas, algorith
 
 Promising packages from Autoware Universe may be **adopted into Autoware Core** when they demonstrate sufficient maturity, stability, and usefulness.
 This creates a natural pipeline from innovation → standardization → production.
+The specific requirements a package must meet are defined in [What belongs in Autoware Core](core-package-inclusion-criteria.md).
 
 !!! info
 


### PR DESCRIPTION
- Adds a new page, **What belongs in Autoware Core**, under Design → Concepts, defining the concrete bar a package must clear to live in Autoware Core and how a package is promoted from Universe.
- Links it from the "Core & Universe repository model" section of the [concepts page](https://github.com/autowarefoundation/autoware-documentation/blob/36953e8961f17e90faf96d64c984c9049419df1c/docs/design/autoware-concepts/index.md) and registers it in the section nav.
- Makes the Core/Universe boundary explicit: dependency direction, vendor-neutral interfaces, the CPU-only default, and the optional `autoware_core_cuda` GPU layer.

## Why

The concepts page says packages are "adopted into Core when they demonstrate sufficient maturity, stability, and usefulness" but never says what that means in practice. This page makes the bar concrete (downward-only dependencies, vendor-neutral interfaces, CPU-only default build, tests plus a stricter clang-tidy gate, and maintainership), so the recurring "is there any requirement to be core?" question has a documented answer and the ongoing repository restructuring has a reference to point to.

---

- Related discussion: [extracting shared CUDA components into core](https://github.com/orgs/autowarefoundation/discussions/7156)
- Related restructuring work: [autowarefoundation/autoware#7090 — Autoware Index](https://github.com/autowarefoundation/autoware/issues/7090)
