### PR TITLE
docs: switch to Cloudflare mirror

### DIFF
--- a/mkdocs-base.yaml
+++ b/mkdocs-base.yaml
@@ -46,7 +46,7 @@ extra_css:
 
 extra_javascript:
   - assets/js/mathjax.js
-  - https://polyfill.io/v3/polyfill.min.js?features=es6
+  - https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=es6
   - https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js
 
 plugins:


### PR DESCRIPTION
## Description

polyfill.io has been compromised (a long time ago).
See https://blog.cloudflare.com/polyfill-io-now-available-on-cdnjs-reduce-your-supply-chain-risk/

This PR switches to the official cloudflare mirror

<img width="1336" height="526" alt="image" src="https://github.com/user-attachments/assets/86f2a5fc-1932-4099-b402-0b6654b691ac" />

Similar PR: https://github.com/autowarefoundation/LSA-reference-design-docs/pull/19


## How was this PR tested?

Tested by the deploy-docs workflow.
