### PR TITLE
docs: add gdown installation instructions where gdown is used

### DIFF
--- a/docs/demos/planning-sim/lane-change.md
+++ b/docs/demos/planning-sim/lane-change.md
@@ -4,7 +4,7 @@
 
    ```bash
    mkdir -p ~/autoware_data/maps
-   gdown -O ~/autoware_data/maps/ 'https://github.com/autowarefoundation/AWSIM/releases/download/v1.1.0/nishishinjuku_autoware_map.zip'
+   wget -P ~/autoware_data/maps/ 'https://github.com/autowarefoundation/AWSIM/releases/download/v1.1.0/nishishinjuku_autoware_map.zip'
    unzip -d ~/autoware_data/maps ~/autoware_data/maps/nishishinjuku_autoware_map.zip
    ```
 

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -66,7 +66,6 @@ sudo apt-get -y install git
     - [Install Ansible](https://github.com/autowarefoundation/autoware/tree/main/ansible#ansible-installation)
     - [Install Build Tools](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/build_tools#manual-installation)
     - [Install Dev Tools](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/dev_tools#manual-installation)
-    - [Install gdown](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/gdown#manual-installation)
     - [Install geographiclib](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/geographiclib#manual-installation)
     - [Install the RMW Implementation](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/rmw_implementation#manual-installation)
     - [Install ROS 2](https://github.com/autowarefoundation/autoware/tree/main/ansible/roles/ros2#manual-installation)

--- a/docs/simulation-evaluation/components_evaluation/localization_evaluation/urban-environment-evaluation.md
+++ b/docs/simulation-evaluation/components_evaluation/localization_evaluation/urban-environment-evaluation.md
@@ -45,6 +45,14 @@ If you test with raw data, you need to follow these `Test With Raw Data` instruc
 
 ##### Installation
 
+If the `gdown` command is not available, install it first:
+
+```bash
+sudo apt-get -y install pipx
+python3 -m pipx ensurepath
+pipx install gdown
+```
+
 1.) Download and unpack a test map files.
 
 - You can also download [the map](https://drive.google.com/file/d/1WPWmFCjV7eQee4kyBpmGNlX7awerCPxc/view?usp=drive_link) manually.
@@ -122,6 +130,14 @@ ros2 bag play ~/autoware_ista_data/rosbag2_2024_09_11-17_53_54_0.db3
 If you only want to see the localization performance, follow the `Localization Test Only` instructions. For those who only want to perform localization tests, a second test bag file and a separate launch file have been created for this test. You can perform this test by following the instructions below.
 
 ##### Installation
+
+If the `gdown` command is not available, install it first:
+
+```bash
+sudo apt-get -y install pipx
+python3 -m pipx ensurepath
+pipx install gdown
+```
 
 1.) Download and unpack a test map files.
 

--- a/docs/tutorials/others/using-divided-map.md
+++ b/docs/tutorials/others/using-divided-map.md
@@ -6,6 +6,14 @@ Divided pointcloud map is necessary when handling large pointcloud map, in which
 
 Download the [sample-map-rosbag_split](https://docs.google.com/uc?export=download&id=11tLC9T4MS8fnZ9Wo0D8-Ext7hEDl2YJ4) and locate the map under `$HOME/autoware_data/maps/`.
 
+If the `gdown` command is not available, install it first:
+
+```bash
+sudo apt-get -y install pipx
+python3 -m pipx ensurepath
+pipx install gdown
+```
+
 ```bash
 mkdir -p ~/autoware_data/maps
 gdown -O ~/autoware_data/maps/ 'https://docs.google.com/uc?export=download&id=11tLC9T4MS8fnZ9Wo0D8-Ext7hEDl2YJ4'


### PR DESCRIPTION
## Description

- Companion to autowarefoundation/autoware#7220, which removes the unused `gdown` ansible role from the dev environment setup. Since `gdown` will no longer be installed by `setup-dev-env.sh`, the documentation pages that use it now carry self-contained installation instructions.

- Add pipx-based `gdown` installation steps before each `gdown` usage in the divided map tutorial and the urban environment localization evaluation page.
- Switch the lane change demo download to `wget`, since it fetches a plain GitHub release URL and does not need `gdown`.
- Remove the stale "Install gdown" entry from the source installation page; the ansible role is removed in autowarefoundation/autoware#7220 and its `#manual-installation` anchor already pointed to a README that no longer exists.

## How was this PR tested?

Tested by the deploy-docs workflow.