### PR TITLE
chore: update the latest stable version to 1.9.0

### DIFF
--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -15,7 +15,7 @@ The two images most users will care about:
 
 Replace `jazzy` with `humble` for ROS 2 Humble.
 
-These tags track the latest build. For a stable release, append the version to the tag — for example, `ghcr.io/autowarefoundation/autoware:universe-jazzy-1.8.0` for the `1.8.0` release on ROS 2 Jazzy.
+These tags track the latest build. For a stable release, append the version to the tag — for example, `ghcr.io/autowarefoundation/autoware:universe-jazzy-1.9.0` for the `1.9.0` release on ROS 2 Jazzy.
 
 For the broader containerized-deployment story (deployment patterns, integrations, edge use cases), see Open AD Kit:
 
@@ -42,7 +42,7 @@ For the broader containerized-deployment story (deployment patterns, integration
    By default, this checks out the `main` branch, which contains the latest in-development changes. If you want to use a stable release, check out the corresponding release tag (compatible with both ROS 2 Humble and Jazzy):
 
    ```bash
-   git checkout 1.8.0
+   git checkout 1.9.0
    ```
 
    The list of available tags can be found on the [autoware releases page](https://github.com/autowarefoundation/autoware/releases).

--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -27,10 +27,10 @@ sudo apt-get -y install git
    cd autoware
    ```
 
-   By default, this checks out the `main` branch, which contains the latest in-development changes. If you want to use a stable release, check out the corresponding release tag. For example, to use the `1.8.0` release (compatible with both ROS 2 Humble and Jazzy):
+   By default, this checks out the `main` branch, which contains the latest in-development changes. If you want to use a stable release, check out the corresponding release tag. For example, to use the `1.9.0` release (compatible with both ROS 2 Humble and Jazzy):
 
    ```bash
-   git checkout 1.8.0
+   git checkout 1.9.0
    ```
 
    The list of available tags can be found on the [autoware releases page](https://github.com/autowarefoundation/autoware/releases).


### PR DESCRIPTION
## Description
Part of https://github.com/autowarefoundation/autoware/issues/7140
Autoware main repo is tagged with 1.9.0, and this will update the documentation to refer to 1.9.0 for the latest stable version.

## How was this PR tested?

Tested by the deploy-docs workflow.
