### PR TITLE
ci(deploy-docs): opt in to fork PR checkout

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -37,6 +37,10 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          # This job builds fork code in a trusted context, so it only runs
+          # after a maintainer adds the tag:deploy-docs label. Review the diff,
+          # including main.py and mkdocs-requirements.txt, before labeling.
+          allow-unsafe-pr-checkout: true
 
       - name: Deploy docs
         uses: autowarefoundation/autoware-github-actions/deploy-docs@v1


### PR DESCRIPTION
`actions/checkout` now refuses to check out fork pull request code from a `pull_request_target` workflow, so the docs preview fails at checkout for every fork PR ([example run](https://github.com/autowarefoundation/autoware-documentation/actions/runs/29983503439/job/89816240788)).

This is a breaking change backported to `v4` in [actions/checkout v4.4.0](https://github.com/actions/checkout/releases/tag/v4.4.0), announced in [Safer `pull_request_target` defaults for GitHub Actions checkout](https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/). The new [`allow-unsafe-pr-checkout` input](https://github.com/actions/checkout#usage) is the documented opt-in; the risks are described in [Securely using `pull_request_target`](https://gh.io/securely-using-pull_request_target).

This sets `allow-unsafe-pr-checkout: true` to restore the previous behavior. The job is already gated behind the `tag:deploy-docs` label, so fork code only runs after a maintainer opts a PR in.
