### PR TITLE
ci(sync-files): stop syncing files this repository owns

### DIFF
--- a/.github/sync-files.yaml
+++ b/.github/sync-files.yaml
@@ -8,7 +8,6 @@
     - source: .github/ISSUE_TEMPLATE/config.yml
     - source: .github/ISSUE_TEMPLATE/task.yaml
     - source: .github/dependabot.yaml
-    - source: .github/pull_request_template.md
     - source: .github/stale.yml
     - source: .github/workflows/comment-on-pr.yaml
     - source: .github/workflows/semantic-pull-request.yaml
@@ -36,10 +35,3 @@
     - source: .prettierrc.yaml
     - source: .yamllint.yaml
     - source: setup.cfg
-
-- repository: autowarefoundation/autoware-documentation
-  files:
-    - source: mkdocs-base.yaml
-      dest: mkdocs.yaml
-      pre-commands: |
-        sd "  - macros" "  - macros:\n      include_yaml:\n        - autoware_interfaces: yaml/autoware-interfaces.yaml" {source}


### PR DESCRIPTION
This repository was listed as a sync source for itself, so every sync overwrote `mkdocs.yaml` with `mkdocs-base.yaml`. That template is the one we distribute to other repositories and it has fallen behind our own config, so the sync reverts recent changes and breaks the build by switching to the unavailable `fontawesome_markdown` extension and the removed `materialx.emoji` module.

- The pull request template was simplified in #735 and refers to the deploy-docs workflow, which is specific to this repository, so it should not be replaced by the shared template either.

- Both files are maintained here, so they are removed from the sync list. See #811 for the changes this prevents.
