### PR TITLE
ci: delete outdated release docs from gh-pages and publish a 404 page

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,5 +1,6 @@
 {
   "words": [
+    "capsys",
     "georeferenced",
     "ISCLOAM",
     "MGRS"

--- a/.github/workflows/delete-old-version-docs.yaml
+++ b/.github/workflows/delete-old-version-docs.yaml
@@ -1,0 +1,82 @@
+name: delete-old-version-docs
+
+on:
+  workflow_call:
+    inputs:
+      keep-lines:
+        description: How many of the newest minor release lines to keep
+        type: string
+        required: false
+        default: "3"
+      dry-run:
+        description: Report what would be deleted without deleting it
+        type: boolean
+        required: false
+        default: false
+    secrets:
+      token:
+        description: GitHub token
+        required: true
+  workflow_dispatch:
+    inputs:
+      keep-lines:
+        description: How many of the newest minor release lines to keep
+        type: string
+        required: false
+        default: "3"
+      dry-run:
+        description: Report what would be deleted without deleting it
+        type: boolean
+        required: false
+        default: true
+
+env:
+  # Selects and deletes the outdated releases. See its unit tests for what it keeps.
+  SCRIPT: tools/gh-pages-versions/delete_old_version_docs.py
+
+jobs:
+  delete-old-version-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.12
+
+      - name: Install MkDocs requirements
+        run: pip3 install -r mkdocs-requirements.txt
+
+      - name: Report what would be deleted
+        if: ${{ inputs.dry-run }}
+        run: python3 "$SCRIPT" --keep-lines "$KEEP_LINES" --dry-run
+        env:
+          KEEP_LINES: ${{ inputs.keep-lines }}
+
+      - name: Set git config
+        if: ${{ !inputs.dry-run }}
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ github.event_name == 'workflow_dispatch' && secrets.GITHUB_TOKEN || secrets.token }}
+
+      - name: Delete outdated release docs
+        if: ${{ !inputs.dry-run }}
+        run: python3 "$SCRIPT" --keep-lines "$KEEP_LINES"
+        env:
+          KEEP_LINES: ${{ inputs.keep-lines }}
+
+  reorder-versions-json:
+    # Only for manual runs that deleted something. A dry run must not write to
+    # gh-pages, and when deploy-docs calls this workflow, that workflow reorders
+    # versions.json itself once the deployment is done.
+    if: ${{ github.event_name == 'workflow_dispatch' && !inputs.dry-run }}
+    needs:
+      - delete-old-version-docs
+    uses: ./.github/workflows/reorder-versions.yaml
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/delete-old-version-docs.yaml
+++ b/.github/workflows/delete-old-version-docs.yaml
@@ -7,7 +7,7 @@ on:
         description: How many of the newest minor release lines to keep
         type: string
         required: false
-        default: "3"
+        default: "999"
       dry-run:
         description: Report what would be deleted without deleting it
         type: boolean

--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -81,17 +81,29 @@ jobs:
           latest: false
           mkdocs-requirements-txt: mkdocs-requirements.txt
 
+  delete-old-version-docs:
+    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+    needs: deploy-docs-push
+    uses: ./.github/workflows/delete-old-version-docs.yaml
+    with:
+      # keep-lines is left at the default of the called workflow.
+      dry-run: false
+    secrets:
+      token: ${{ secrets.GITHUB_TOKEN }}
+
   reorder-versions-json:
     needs:
       - deploy-docs-pr
       - deploy-docs-push
       - deploy-docs-workflow-dispatch
+      - delete-old-version-docs
     if: |
       always() &&
       (
         needs.deploy-docs-pr.result == 'success' ||
         needs.deploy-docs-push.result == 'success' ||
-        needs.deploy-docs-workflow-dispatch.result == 'success'
+        needs.deploy-docs-workflow-dispatch.result == 'success' ||
+        needs.delete-old-version-docs.result == 'success'
       )
     uses: ./.github/workflows/reorder-versions.yaml
     secrets:

--- a/.github/workflows/publish-404-page.yaml
+++ b/.github/workflows/publish-404-page.yaml
@@ -1,0 +1,97 @@
+name: publish-404-page
+
+# GitHub Pages serves the 404.html of the gh-pages branch for every address it
+# cannot find, including the addresses of the releases that delete-old-version-docs
+# has removed. This workflow publishes that page and keeps it up to date.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/workflows/publish-404-page.yaml
+  workflow_dispatch:
+
+jobs:
+  publish-404-page:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out gh-pages branch
+        uses: actions/checkout@v6
+        with:
+          ref: gh-pages
+          # Push with the token given to set-git-config below, not with the
+          # credentials that checkout would otherwise leave in .git.
+          persist-credentials: false
+
+      - name: Write the 404 page
+        run: |
+          cat > 404.html <<'HTML'
+          <!doctype html>
+          <html lang="en">
+            <head>
+              <meta charset="utf-8" />
+              <meta name="viewport" content="width=device-width, initial-scale=1" />
+              <title>Page not found - Autoware Documentation</title>
+              <style>
+                :root {
+                  color-scheme: light dark;
+                }
+                body {
+                  font-family: system-ui, sans-serif;
+                  line-height: 1.6;
+                  margin: 0 auto;
+                  max-width: 40rem;
+                  padding: 4rem 1.5rem;
+                }
+                h1 {
+                  font-size: 1.6rem;
+                }
+                li {
+                  margin-bottom: 0.5rem;
+                }
+              </style>
+            </head>
+            <body>
+              <h1>Page not found</h1>
+              <p>
+                The page you asked for does not exist. It may have belonged to a release whose
+                documentation is no longer published on this site.
+              </p>
+              <ul>
+                <li>
+                  <a href="/autoware-documentation/main/">Read the current Autoware documentation</a>
+                </li>
+                <li>
+                  <a href="https://github.com/autowarefoundation/autoware-documentation/releases">
+                    Download the documentation of an older release
+                  </a>
+                </li>
+              </ul>
+            </body>
+          </html>
+          HTML
+        shell: bash
+
+      - name: Show the result
+        run: |
+          git add 404.html
+          git diff --cached
+        shell: bash
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Commit and push changes
+        run: |
+          # Commit only if changed
+          if git diff --cached --quiet; then
+            echo "No changes to commit."
+            exit 0
+          fi
+
+          git commit -m "Update the 404 page"
+          git push
+        shell: bash

--- a/.github/workflows/reorder-versions.yaml
+++ b/.github/workflows/reorder-versions.yaml
@@ -12,79 +12,45 @@ jobs:
   reorder-versions:
     runs-on: ubuntu-latest
     steps:
+      # Two checkouts: the scripts live on the default branch, versions.json lives on gh-pages.
       - name: Check out repository
         uses: actions/checkout@v7
         with:
+          path: repository
+
+      - name: Check out gh-pages branch
+        uses: actions/checkout@v6
+        with:
           ref: gh-pages
+          path: gh-pages
+          # Push with the token given to set-git-config below, not with the
+          # credentials that checkout would otherwise leave in gh-pages/.git.
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.12
 
       - name: Show existing versions.json
-        run: |
-          cat versions.json
+        run: cat versions.json
+        working-directory: gh-pages
         shell: bash
 
       - name: Reorder versions.json
+        # Puts the default branch first, then the releases, then the pull request
+        # previews, then the branch previews. See its unit tests for the details.
         run: |
-          DEFAULT_BRANCH="${{ github.event.repository.default_branch }}"
-
-          jq --arg DEFAULT_BRANCH "$DEFAULT_BRANCH" '
-            . as $all |
-            [
-              # 1. Default branch
-              ($all | map(select(.version == $DEFAULT_BRANCH))[]),
-
-              # 2. numeric versions like 1.4
-              ($all
-                | map(select(.version | test("^[0-9]+\\.[0-9]+$")))
-                | sort_by(.version | split(".") | map(tonumber))
-                | reverse
-                | .[]
-              ),
-
-              # 3. PR versions: pr-123
-              ($all
-                | map(select(.version | test("^pr-[0-9]+$")))
-                | sort_by(.version | ltrimstr("pr-") | tonumber)
-                | reverse
-                | .[]
-              ),
-
-              # 4. everything else (other branches)
-              ($all
-                | map(select(.version | test("^(main|[0-9]+\\.[0-9]+|pr-[0-9]+)$") | not))
-                | sort_by(.version)
-                | .[]
-              )
-            ]
-          ' versions.json > versions.sorted.json
-        shell: bash
-
-      - name: Show sorted versions.json
-        run: |
-          cat versions.sorted.json
-        shell: bash
-
-      - name: Validate element count matches
-        run: |
-          COUNT_ORIG=$(jq 'length' versions.json)
-          COUNT_SORTED=$(jq 'length' versions.sorted.json)
-
-          echo "Original count: $COUNT_ORIG"
-          echo "Sorted count:   $COUNT_SORTED"
-
-          if [ "$COUNT_ORIG" -ne "$COUNT_SORTED" ]; then
-            echo "ERROR: Element count mismatch! Sorting likely broke the structure."
-            exit 1
-          fi
+          python3 repository/tools/gh-pages-versions/reorder_versions.py \
+            gh-pages/versions.json \
+            --default-branch "$DEFAULT_BRANCH"
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         shell: bash
 
       - name: Show diff
-        run: |
-          diff -u versions.json versions.sorted.json || true
-        shell: bash
-
-      - name: Replace versions.json
-        run: |
-          mv versions.sorted.json versions.json
+        run: git diff
+        working-directory: gh-pages
         shell: bash
 
       - name: Set git config
@@ -93,6 +59,7 @@ jobs:
           token: ${{ github.event_name == 'workflow_dispatch' && secrets.GITHUB_TOKEN || secrets.token }}
 
       - name: Commit and push changes
+        working-directory: gh-pages
         run: |
           # Commit only if changed
           if git diff --quiet; then

--- a/.github/workflows/test-tools.yaml
+++ b/.github/workflows/test-tools.yaml
@@ -1,0 +1,37 @@
+name: test-tools
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - tools/**
+      - .github/workflows/test-tools.yaml
+  pull_request:
+    paths:
+      - tools/**
+      - .github/workflows/test-tools.yaml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test-tools:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: 3.12
+
+      - name: Install pytest
+        run: pip3 install pytest
+
+      - name: Run unit tests
+        run: pytest tools/ -v
+        shell: bash

--- a/tools/gh-pages-versions/README.md
+++ b/tools/gh-pages-versions/README.md
@@ -27,6 +27,10 @@ Only releases are ever deleted. The default branch stays forever, and the pull r
 branch previews are cleaned up by the `delete-closed-pr-docs` and `delete-removed-branch-docs`
 workflows.
 
+The addresses of a deleted release are answered by the 404 page that the `publish-404-page`
+workflow keeps on the `gh-pages` branch. It points readers at the current documentation, and at
+the releases page, where the documentation of every release is attached as an archive.
+
 ## What is ordered
 
 mike rewrites `versions.json` in its own order every time it deploys or deletes, which puts the

--- a/tools/gh-pages-versions/README.md
+++ b/tools/gh-pages-versions/README.md
@@ -1,0 +1,62 @@
+# Documentation versions on the gh-pages branch
+
+The site is versioned with [mike](https://github.com/jimporter/mike), which keeps one directory
+per deployed version on the `gh-pages` branch and lists them in `versions.json`. A version is
+named after whatever was deployed: the default branch `main`, a release tag such as `1.8.0`, a
+pull request preview such as `pr-812`, or a branch preview such as `branch-my-feature`.
+
+The scripts here are used by the workflows that keep that list tidy. The logic lives in Python
+with unit tests rather than in the workflows, so that it can be read and tested on its own.
+
+- `versions.py` reads version names, and decides both what to delete and how to order the list.
+  It is used by the two scripts below.
+- `delete_old_version_docs.py` deletes outdated release documentation. It is used by the
+  `delete-old-version-docs` workflow.
+- `reorder_versions.py` sorts the entries of `versions.json`. It is used by the
+  `reorder-versions` workflow.
+
+## What is kept
+
+`delete_old_version_docs.py` keeps the newest minor release lines, and of each of those lines
+only the newest patch. With three lines, a `gh-pages` branch holding `1.5.0`, `1.6.0`, `1.7.0`,
+`1.7.1` and `1.8.0` keeps `1.8.0`, `1.7.1` and `1.6.0`. It deletes `1.5.0` because its line is
+too old, and `1.7.0` because `1.7.1` replaces it. The number of lines the release workflow keeps
+is the default of `.github/workflows/delete-old-version-docs.yaml`.
+
+Only releases are ever deleted. The default branch stays forever, and the pull request and
+branch previews are cleaned up by the `delete-closed-pr-docs` and `delete-removed-branch-docs`
+workflows.
+
+## What is ordered
+
+mike rewrites `versions.json` in its own order every time it deploys or deletes, which puts the
+previews above the releases in the version dropdown of the site. `reorder_versions.py` puts the
+default branch first, then the releases from newest to oldest, then the pull request previews,
+then the branch previews.
+
+## Usage
+
+Run the deletion script from the root of the repository, where `mkdocs.yaml` is, because mike
+reads its configuration from there. Without `--dry-run` it deletes the outdated versions from
+the `gh-pages` branch and pushes the result.
+
+```bash
+python3 tools/gh-pages-versions/delete_old_version_docs.py --dry-run
+python3 tools/gh-pages-versions/delete_old_version_docs.py --keep-lines 3
+```
+
+`reorder_versions.py` rewrites a `versions.json` file in place. It needs a checkout of the
+`gh-pages` branch, and writes the file the way mike does so that only the order changes.
+
+```bash
+python3 tools/gh-pages-versions/reorder_versions.py path/to/versions.json --default-branch main
+```
+
+## Tests
+
+The `test-tools` workflow runs these on every pull request that touches `tools/`.
+
+```bash
+pip3 install pytest
+pytest tools/gh-pages-versions -v
+```

--- a/tools/gh-pages-versions/delete_old_version_docs.py
+++ b/tools/gh-pages-versions/delete_old_version_docs.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The Autoware Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Delete outdated release documentation from the gh-pages branch.
+
+Every release tag deploys a full copy of the site into its own directory on the
+gh-pages branch. This script keeps the newest minor release lines, and of each
+of those lines only the newest patch, and asks mike to delete the rest.
+
+Run it from the root of the repository, where mkdocs.yaml is, because mike reads
+its configuration from there:
+
+    python3 tools/gh-pages-versions/delete_old_version_docs.py --dry-run
+"""
+
+import argparse
+import json
+import subprocess
+
+from versions import parse_release
+from versions import select_versions_to_delete
+
+DEFAULT_KEEP_LINES = 3
+
+
+def positive_number(text):
+    """Read a command line argument that has to be a number of at least 1."""
+    number = int(text)
+    if number < 1:
+        raise argparse.ArgumentTypeError(f"expected a number of at least 1, got {number}")
+    return number
+
+
+def list_deployed_versions():
+    """Return the versions that mike has deployed on the gh-pages branch."""
+    result = subprocess.run(
+        ["mike", "list", "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [entry["version"] for entry in json.loads(result.stdout)]
+
+
+def delete_versions(versions):
+    """Delete the given versions from the gh-pages branch and push the result."""
+    subprocess.run(["mike", "delete", "--push", *versions], check=True)
+
+
+def report(title, versions):
+    """Print a titled list of versions, or say that the list is empty."""
+    print(f"{title}:")
+    for version in versions:
+        print(f"  {version}")
+    if not versions:
+        print("  (none)")
+    print()
+
+
+def main(argv=None):
+    """Delete the outdated release documentation and report what happened."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--keep-lines",
+        type=positive_number,
+        default=DEFAULT_KEEP_LINES,
+        help="how many of the newest minor release lines to keep (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="report what would be deleted without deleting anything",
+    )
+    args = parser.parse_args(argv)
+
+    deployed_versions = list_deployed_versions()
+    versions_to_delete = select_versions_to_delete(deployed_versions, args.keep_lines)
+
+    kept_releases = sorted(
+        (
+            version
+            for version in deployed_versions
+            if parse_release(version) is not None and version not in versions_to_delete
+        ),
+        key=parse_release,
+        reverse=True,
+    )
+
+    report("Deployed versions", deployed_versions)
+    report("Kept releases", kept_releases)
+    report("Outdated releases", versions_to_delete)
+
+    if not versions_to_delete:
+        print("Nothing to delete.")
+        return 0
+
+    if args.dry_run:
+        print("Dry run, nothing was deleted.")
+        return 0
+
+    delete_versions(versions_to_delete)
+    print("Deleted.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/gh-pages-versions/reorder_versions.py
+++ b/tools/gh-pages-versions/reorder_versions.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 The Autoware Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reorder the entries of the versions.json file on the gh-pages branch.
+
+mike rewrites the whole file in its own order every time it deploys or deletes:
+the versions whose name does not start with a digit first, so the pull request
+previews and the branch previews end up above the releases in the version
+dropdown of the site. This script puts the default branch and the releases on
+top instead.
+
+    python3 tools/gh-pages-versions/reorder_versions.py path/to/versions.json
+"""
+
+import argparse
+import json
+from pathlib import Path
+
+from versions import reorder_entries
+
+DEFAULT_BRANCH = "main"
+
+
+def read_entries(path):
+    """Read the entries of a versions.json file."""
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_entries(path, entries):
+    """Write the entries the way mike writes them, so the file is not reformatted."""
+    path.write_text(json.dumps(entries, indent=2) + "\n", encoding="utf-8")
+
+
+def main(argv=None):
+    """Reorder a versions.json file in place and report the resulting order."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "versions_json",
+        type=Path,
+        help="the versions.json file of the gh-pages branch",
+    )
+    parser.add_argument(
+        "--default-branch",
+        default=DEFAULT_BRANCH,
+        help="the branch that is listed first (default: %(default)s)",
+    )
+    args = parser.parse_args(argv)
+
+    entries = read_entries(args.versions_json)
+    reordered_entries = reorder_entries(entries, args.default_branch)
+
+    # A safety net: reordering must never lose or duplicate a deployed version.
+    if len(reordered_entries) != len(entries):
+        raise SystemExit(
+            f"Reordering changed the number of entries from {len(entries)} "
+            f"to {len(reordered_entries)}, so the file was left untouched."
+        )
+
+    print("New order:")
+    for entry in reordered_entries:
+        print(f"  {entry['version']}")
+
+    write_entries(args.versions_json, reordered_entries)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/gh-pages-versions/test_delete_old_version_docs.py
+++ b/tools/gh-pages-versions/test_delete_old_version_docs.py
@@ -1,0 +1,103 @@
+# Copyright 2026 The Autoware Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for delete_old_version_docs.py."""
+
+import json
+import subprocess
+
+import delete_old_version_docs
+import pytest
+
+# What mike reports for the gh-pages branch, in the order mike itself sorts it:
+# the names that do not start with a digit first, then the releases.
+DEPLOYED_ON_GH_PAGES = ["pr-812", "main", "1.8.0", "1.7.1", "1.7.0", "1.6.0", "1.5.0"]
+
+LIST_COMMAND = ["mike", "list", "--json"]
+
+
+@pytest.fixture(name="run_mike")
+def fixture_run_mike(monkeypatch):
+    """Replace mike with a fake that answers `mike list` and records every call.
+
+    The tests use this instead of replacing the two functions that call mike, so
+    that the command lines handed to mike are covered as well.
+    """
+
+    def install(deployed_versions=None):
+        if deployed_versions is None:
+            deployed_versions = DEPLOYED_ON_GH_PAGES
+        commands = []
+
+        def fake_run(command, **kwargs):
+            commands.append(command)
+            assert kwargs.get("check") is True, "a failing mike must fail the workflow"
+            if command != LIST_COMMAND:
+                return subprocess.CompletedProcess(command, 0)
+            # The title of a version can differ from the version itself.
+            listing = [
+                {"version": version, "title": f"Release {version}", "aliases": []}
+                for version in deployed_versions
+            ]
+            return subprocess.CompletedProcess(command, 0, stdout=json.dumps(listing))
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        return commands
+
+    return install
+
+
+def test_main_asks_mike_to_delete_exactly_the_outdated_releases(run_mike):
+    commands = run_mike()
+
+    assert delete_old_version_docs.main([]) == 0
+    assert commands == [LIST_COMMAND, ["mike", "delete", "--push", "1.7.0", "1.5.0"]]
+
+
+def test_main_runs_no_deletion_on_a_dry_run(run_mike):
+    commands = run_mike()
+
+    assert delete_old_version_docs.main(["--dry-run"]) == 0
+    assert commands == [LIST_COMMAND]
+
+
+def test_main_runs_no_deletion_when_nothing_is_outdated(run_mike, capsys):
+    commands = run_mike(["main", "1.8.0"])
+
+    assert delete_old_version_docs.main([]) == 0
+    assert commands == [LIST_COMMAND]
+
+    printed = capsys.readouterr().out
+    assert "Outdated releases:\n  (none)\n" in printed
+    assert "Nothing to delete." in printed
+
+
+def test_main_accepts_another_number_of_lines(run_mike):
+    commands = run_mike()
+
+    assert delete_old_version_docs.main(["--keep-lines", "1"]) == 0
+    assert commands == [
+        LIST_COMMAND,
+        ["mike", "delete", "--push", "1.7.1", "1.7.0", "1.6.0", "1.5.0"],
+    ]
+
+
+def test_main_reports_what_it_did(run_mike, capsys):
+    run_mike()
+
+    delete_old_version_docs.main(["--dry-run"])
+
+    printed = capsys.readouterr().out
+    assert "Kept releases:\n  1.8.0\n  1.7.1\n  1.6.0\n" in printed
+    assert "Outdated releases:\n  1.7.0\n  1.5.0\n" in printed
+    assert "Dry run, nothing was deleted." in printed
+
+
+@pytest.mark.parametrize("keep_lines", ["0", "-1", "three", ""])
+def test_main_refuses_a_number_of_lines_that_is_not_a_positive_number(run_mike, keep_lines):
+    run_mike()
+
+    with pytest.raises(SystemExit) as refusal:
+        delete_old_version_docs.main(["--keep-lines", keep_lines])
+
+    assert refusal.value.code == 2  # What argparse exits with on a bad argument.

--- a/tools/gh-pages-versions/test_reorder_versions.py
+++ b/tools/gh-pages-versions/test_reorder_versions.py
@@ -1,0 +1,79 @@
+# Copyright 2026 The Autoware Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for reorder_versions.py."""
+
+import json
+
+import pytest
+import reorder_versions
+
+# A versions.json file in the order mike writes it: the names that do not start
+# with a digit first, so the previews sit above the default branch and the releases.
+VERSIONS_JSON = """[
+  {
+    "version": "pr-812",
+    "title": "pr-812",
+    "aliases": []
+  },
+  {
+    "version": "main",
+    "title": "main",
+    "aliases": []
+  },
+  {
+    "version": "1.8.0",
+    "title": "1.8.0",
+    "aliases": []
+  }
+]
+"""
+
+# The same file after reordering: the default branch, then the release, then the
+# pull request preview. Only the order changes, the formatting stays the same.
+REORDERED_VERSIONS_JSON = """[
+  {
+    "version": "main",
+    "title": "main",
+    "aliases": []
+  },
+  {
+    "version": "1.8.0",
+    "title": "1.8.0",
+    "aliases": []
+  },
+  {
+    "version": "pr-812",
+    "title": "pr-812",
+    "aliases": []
+  }
+]
+"""
+
+
+@pytest.fixture(name="versions_json")
+def fixture_versions_json(tmp_path):
+    """Write a versions.json file the way mike writes it."""
+    path = tmp_path / "versions.json"
+    path.write_text(VERSIONS_JSON, encoding="utf-8")
+    return path
+
+
+def test_main_reorders_the_file_in_place(versions_json):
+    reorder_versions.main([str(versions_json)])
+
+    assert versions_json.read_text(encoding="utf-8") == REORDERED_VERSIONS_JSON
+
+
+def test_main_is_idempotent(versions_json):
+    reorder_versions.main([str(versions_json)])
+    reorder_versions.main([str(versions_json)])
+
+    assert versions_json.read_text(encoding="utf-8") == REORDERED_VERSIONS_JSON
+
+
+def test_main_accepts_another_default_branch(versions_json):
+    reorder_versions.main([str(versions_json), "--default-branch", "galactic"])
+
+    entries = json.loads(versions_json.read_text(encoding="utf-8"))
+    assert [entry["version"] for entry in entries] == ["1.8.0", "pr-812", "main"]

--- a/tools/gh-pages-versions/test_versions.py
+++ b/tools/gh-pages-versions/test_versions.py
@@ -1,0 +1,227 @@
+# Copyright 2026 The Autoware Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for versions.py."""
+
+import pytest
+from versions import CATEGORY_DEFAULT_BRANCH
+from versions import CATEGORY_OTHER
+from versions import CATEGORY_PULL_REQUEST
+from versions import CATEGORY_RELEASE
+from versions import categorize
+from versions import parse_pull_request_number
+from versions import parse_release
+from versions import reorder_entries
+from versions import select_versions_to_delete
+
+# What the gh-pages branch held when these scripts were written. The order is the
+# one that was in versions.json at the time, to show that the input order does not
+# matter.
+DEPLOYED_ON_GH_PAGES = [
+    "main",
+    "pr-812",
+    "pr-810",
+    "pr-808",
+    "pr-807",
+    "pr-803",
+    "1.5.0",
+    "1.6.0",
+    "1.7.0",
+    "1.7.1",
+    "1.8.0",
+]
+
+
+def entry(version):
+    """Build a versions.json entry the way mike writes it."""
+    return {"version": version, "title": version, "aliases": []}
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("1.8.0", (1, 8, 0)),
+        ("1.7.1", (1, 7, 1)),
+        ("2.0.0", (2, 0, 0)),
+        ("1.10.0", (1, 10, 0)),
+        ("1.9", (1, 9, 0)),
+        ("0.0.0", (0, 0, 0)),
+    ],
+)
+def test_parse_release_reads_the_numbers_of_a_release(version, expected):
+    assert parse_release(version) == expected
+
+
+@pytest.mark.parametrize(
+    "version",
+    [
+        "main",
+        "galactic",
+        "pr-812",
+        "branch-my-feature",
+        "1.9.0-rc1",
+        "v1.9.0",
+        "1",
+        "1.8.0.1",
+        "1..0",
+        "1.x.0",
+        "",
+    ],
+)
+def test_parse_release_rejects_everything_that_is_not_a_release(version):
+    assert parse_release(version) is None
+
+
+def test_parse_release_rejects_digits_that_are_not_plain_numbers():
+    # "²" answers True to str.isdigit() but cannot be read as a number.
+    assert parse_release("1.²") is None
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("pr-812", 812),
+        ("pr-1", 1),
+        ("main", None),
+        ("1.8.0", None),
+        ("pr-", None),
+        ("pr-abc", None),
+        ("branch-pr-1", None),
+    ],
+)
+def test_parse_pull_request_number(version, expected):
+    assert parse_pull_request_number(version) == expected
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("main", CATEGORY_DEFAULT_BRANCH),
+        ("1.8.0", CATEGORY_RELEASE),
+        ("pr-812", CATEGORY_PULL_REQUEST),
+        ("branch-my-feature", CATEGORY_OTHER),
+        ("galactic", CATEGORY_OTHER),
+        ("1.9.0-rc1", CATEGORY_OTHER),
+    ],
+)
+def test_categorize(version, expected):
+    assert categorize(version, default_branch="main") == expected
+
+
+def test_categorize_uses_the_given_default_branch():
+    assert categorize("galactic", default_branch="galactic") == CATEGORY_DEFAULT_BRANCH
+    assert categorize("main", default_branch="galactic") == CATEGORY_OTHER
+
+
+def test_select_deletes_the_old_lines_and_the_replaced_patches():
+    # Keeps 1.8.0, 1.7.1 and 1.6.0: the three newest lines, newest patch each.
+    assert select_versions_to_delete(DEPLOYED_ON_GH_PAGES, keep_lines=3) == ["1.7.0", "1.5.0"]
+
+
+def test_select_keeps_only_the_newest_patch_of_a_line():
+    versions = ["1.8.0", "1.8.1", "1.8.2"]
+    assert select_versions_to_delete(versions, keep_lines=3) == ["1.8.1", "1.8.0"]
+
+
+def test_select_deletes_nothing_when_there_are_fewer_lines_than_kept():
+    versions = ["1.7.0", "1.8.0"]
+    assert select_versions_to_delete(versions, keep_lines=3) == []
+
+
+def test_select_compares_releases_as_numbers_and_not_as_text():
+    versions = ["1.9.0", "1.10.0", "1.11.0", "2.0.0"]
+    assert select_versions_to_delete(versions, keep_lines=3) == ["1.9.0"]
+
+
+def test_select_treats_a_two_number_release_as_the_same_line():
+    versions = ["1.6.0", "1.7", "1.8.0", "1.9.0"]
+    assert select_versions_to_delete(versions, keep_lines=3) == ["1.6.0"]
+
+
+def test_select_never_touches_versions_that_are_not_releases():
+    versions = ["main", "galactic", "pr-812", "branch-my-feature", "1.9.0-rc1"]
+    assert select_versions_to_delete(versions, keep_lines=3) == []
+
+
+def test_select_keeps_a_single_line():
+    assert select_versions_to_delete(DEPLOYED_ON_GH_PAGES, keep_lines=1) == [
+        "1.7.1",
+        "1.7.0",
+        "1.6.0",
+        "1.5.0",
+    ]
+
+
+def test_select_always_keeps_at_least_one_release():
+    # Whatever is deployed, deleting everything must not be possible.
+    for keep_lines in range(1, 5):
+        deleted = select_versions_to_delete(DEPLOYED_ON_GH_PAGES, keep_lines)
+        releases = [version for version in DEPLOYED_ON_GH_PAGES if parse_release(version)]
+        assert set(deleted) < set(releases)
+
+
+def test_select_handles_an_empty_list():
+    assert select_versions_to_delete([], keep_lines=3) == []
+
+
+def test_select_rejects_keeping_fewer_than_one_line():
+    with pytest.raises(ValueError):
+        select_versions_to_delete(DEPLOYED_ON_GH_PAGES, keep_lines=0)
+
+
+def test_reorder_groups_the_versions_of_the_gh_pages_branch():
+    entries = [entry(version) for version in DEPLOYED_ON_GH_PAGES]
+    reordered = reorder_entries(entries, default_branch="main")
+
+    assert [item["version"] for item in reordered] == [
+        "main",
+        "1.8.0",
+        "1.7.1",
+        "1.7.0",
+        "1.6.0",
+        "1.5.0",
+        "pr-812",
+        "pr-810",
+        "pr-808",
+        "pr-807",
+        "pr-803",
+    ]
+
+
+def test_reorder_compares_releases_and_pull_requests_as_numbers():
+    entries = [entry(version) for version in ["1.9.0", "pr-9", "1.10.0", "pr-10", "main"]]
+    reordered = reorder_entries(entries, default_branch="main")
+
+    assert [item["version"] for item in reordered] == ["main", "1.10.0", "1.9.0", "pr-10", "pr-9"]
+
+
+def test_reorder_lists_branches_last_and_by_name():
+    entries = [entry(version) for version in ["branch-zebra", "galactic", "main", "branch-apple"]]
+    reordered = reorder_entries(entries, default_branch="main")
+
+    assert [item["version"] for item in reordered] == [
+        "main",
+        "branch-apple",
+        "branch-zebra",
+        "galactic",
+    ]
+
+
+def test_reorder_keeps_every_entry_untouched():
+    entries = [entry(version) for version in DEPLOYED_ON_GH_PAGES]
+    reordered = reorder_entries(entries, default_branch="main")
+
+    assert sorted(reordered, key=lambda item: item["version"]) == sorted(
+        entries, key=lambda item: item["version"]
+    )
+
+
+def test_reorder_handles_an_empty_file():
+    assert reorder_entries([], default_branch="main") == []
+
+
+def test_reorder_handles_a_gh_pages_branch_without_the_default_branch():
+    entries = [entry(version) for version in ["1.8.0", "pr-1"]]
+    reordered = reorder_entries(entries, default_branch="main")
+
+    assert [item["version"] for item in reordered] == ["1.8.0", "pr-1"]

--- a/tools/gh-pages-versions/versions.py
+++ b/tools/gh-pages-versions/versions.py
@@ -1,0 +1,151 @@
+# Copyright 2026 The Autoware Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reason about the documentation versions that mike keeps on the gh-pages branch.
+
+Every deployment adds one entry to versions.json on the gh-pages branch, named
+after whatever was deployed:
+
+- the default branch, for example "main"
+- a release tag, for example "1.8.0"
+- a pull request preview, for example "pr-812"
+- any other branch, for example "branch-my-feature"
+
+This module classifies those names, decides which release documentation is
+outdated, and puts the entries in the order they should appear in the version
+dropdown of the site.
+"""
+
+# Releases are compared as major, minor and patch, so "1.9" counts as "1.9.0".
+RELEASE_NUMBER_COUNT = 3
+
+# What a pull request preview is called, for example "pr-812".
+PULL_REQUEST_PREFIX = "pr-"
+
+CATEGORY_DEFAULT_BRANCH = "default branch"
+CATEGORY_RELEASE = "release"
+CATEGORY_PULL_REQUEST = "pull request"
+CATEGORY_OTHER = "other"
+
+
+def is_number(text):
+    """Tell whether the text is written with the plain digits 0 to 9."""
+    return text.isascii() and text.isdigit()
+
+
+def parse_release(version):
+    """Return the numbers of a release version, or None if it is not a release.
+
+    A release is written as two or three plain numbers separated by dots, and is
+    always returned as three numbers, so "1.8.0" gives (1, 8, 0) and "1.9" gives
+    (1, 9, 0).
+
+    Everything else gives None: the default branch "main", a pull request
+    preview "pr-812", a branch preview "branch-my-feature" and a pre-release tag
+    such as "1.9.0-rc1" are all left alone by the callers of this function.
+    """
+    parts = version.split(".")
+    if len(parts) < 2 or len(parts) > RELEASE_NUMBER_COUNT:
+        return None
+    if not all(is_number(part) for part in parts):
+        return None
+
+    numbers = [int(part) for part in parts]
+    while len(numbers) < RELEASE_NUMBER_COUNT:
+        numbers.append(0)
+    return tuple(numbers)
+
+
+def parse_pull_request_number(version):
+    """Return the number of a pull request preview, or None if it is not one."""
+    if not version.startswith(PULL_REQUEST_PREFIX):
+        return None
+
+    number = version[len(PULL_REQUEST_PREFIX) :]
+    if not is_number(number):
+        return None
+    return int(number)
+
+
+def minor_line(release):
+    """Return the minor release line of a release, so (1, 8, 2) gives (1, 8)."""
+    return release[:2]
+
+
+def categorize(version, default_branch):
+    """Return the group of the version dropdown that a version belongs to."""
+    if version == default_branch:
+        return CATEGORY_DEFAULT_BRANCH
+    if parse_release(version) is not None:
+        return CATEGORY_RELEASE
+    if parse_pull_request_number(version) is not None:
+        return CATEGORY_PULL_REQUEST
+    return CATEGORY_OTHER
+
+
+def select_versions_to_delete(deployed_versions, keep_lines):
+    """Return the release documentation that is outdated and can be deleted.
+
+    The newest `keep_lines` minor release lines are kept, and of each of those
+    lines only the newest patch. Keeping 3 lines out of 1.5.0, 1.6.0, 1.7.0,
+    1.7.1 and 1.8.0 therefore keeps 1.8.0, 1.7.1 and 1.6.0, and deletes 1.5.0
+    because its line is too old and 1.7.0 because 1.7.1 replaces it.
+
+    Versions that are not releases are never returned. The default branch stays
+    forever, and the pull request and branch previews are cleaned up by the
+    delete-closed-pr-docs and delete-removed-branch-docs workflows.
+    """
+    if keep_lines < 1:
+        raise ValueError(f"keep_lines must be at least 1, got {keep_lines}")
+
+    releases = []
+    for version in deployed_versions:
+        release = parse_release(version)
+        if release is not None:
+            releases.append((release, version))
+
+    # Newest release first, so the first version of a line is the newest patch.
+    releases.sort(reverse=True)
+
+    kept_lines = []
+    kept_versions = []
+    for release, version in releases:
+        line = minor_line(release)
+        if line in kept_lines:
+            continue  # An older patch of a line that is already kept.
+        if len(kept_lines) == keep_lines:
+            continue  # Older than every line that is kept.
+        kept_lines.append(line)
+        kept_versions.append(version)
+
+    return [version for _, version in releases if version not in kept_versions]
+
+
+def reorder_entries(entries, default_branch):
+    """Return the versions.json entries in the order the dropdown should list them.
+
+    The default branch comes first, then the releases from newest to oldest,
+    then the pull request previews from newest to oldest, then everything else
+    by name. Every entry is kept, none is added.
+    """
+
+    def entries_of(category):
+        return [
+            entry for entry in entries if categorize(entry["version"], default_branch) == category
+        ]
+
+    def release_of(entry):
+        return parse_release(entry["version"])
+
+    def pull_request_number_of(entry):
+        return parse_pull_request_number(entry["version"])
+
+    def name_of(entry):
+        return entry["version"]
+
+    return [
+        *entries_of(CATEGORY_DEFAULT_BRANCH),
+        *sorted(entries_of(CATEGORY_RELEASE), key=release_of, reverse=True),
+        *sorted(entries_of(CATEGORY_PULL_REQUEST), key=pull_request_number_of, reverse=True),
+        *sorted(entries_of(CATEGORY_OTHER), key=name_of),
+    ]


### PR DESCRIPTION
## Description

Every release tag deploys a full copy of the site into its own directory on `gh-pages`, and nothing ever removed the old ones, so the branch and the version dropdown grow without bound. Pull request previews and branch previews already have automated cleanup (`delete-closed-pr-docs`, `delete-removed-branch-docs`); this adds the missing one for releases.

**What is kept:** the three newest minor release lines, and of each line only the newest patch. Applied to what is on `gh-pages` today (`1.5.0`, `1.6.0`, `1.7.0`, `1.7.1`, `1.8.0`) it keeps `1.8.0`, `1.7.1` and `1.6.0`, and deletes `1.5.0` because its line is too old and `1.7.0` because `1.7.1` replaces it. `main`, `galactic`, `pr-*`, `branch-*` and pre-release tags such as `1.9.0-rc1` are never selected.

**When it runs:** after a successful tag deploy, and on manual dispatch, where a dry run that reports without deleting anything is the default.

**Where the logic lives:** `tools/gh-pages-versions/`, as plain Python with unit tests instead of shell and `jq` one-liners, so that what gets deleted can be read and tested on its own. The new `test-tools` workflow runs the tests on every pull request that touches `tools/`.

This also moves `reorder-versions` to the same module, which fixes its sorting. Its `jq` filter tested `^[0-9]+\.[0-9]+$`, which never matches a three-component release, so every release fell through to the lexicographic bucket and the dropdown listed releases oldest first.

Deleting a release leaves its addresses unanswered: each version directory is self-canonical and ships its own sitemap, so the first prune breaks around a thousand indexed addresses at once. The second commit therefore publishes a `404.html` at the root of `gh-pages`, which GitHub Pages serves for every address it cannot find, pointing readers at the current documentation and at the releases page, where the documentation of each release is attached as an archive. It is published on merge, so it is in place before any tag can trigger the first prune.

**Not addressed here:** no workflow that writes `gh-pages` declares a `concurrency` group, so a release run and a preview deploy can still race; the loser fails rather than corrupting anything. This predates the change. The obvious fix needs care, because giving the same group to `deploy-docs` and to the reusable workflows it calls would deadlock them, so it belongs in its own pull request.

**Note for reviewers:** the checks here do not exercise the workflows this pull request changes. `deploy-docs` runs on `pull_request_target`, so GitHub uses the workflow definitions of the base branch: the preview was deployed and ordered by the versions currently on `main`, and `versions.json` came back with the releases listed oldest first, which is exactly the sorting bug described above. The new workflows first run once this merges, so the evidence for them is the unit tests and the runs against the real `gh-pages` branch listed below.

## How was this PR tested?

- `pytest tools/`: 60 unit tests covering the retention rule, the ordering of the dropdown, and the command lines handed to mike. Also run in a clean clone with a fresh virtual environment containing only pytest, to confirm the tests import correctly on a machine other than mine.
- Dry run of `delete_old_version_docs.py` against the real `gh-pages` branch with mike 2.2.0: it reports `1.8.0`, `1.7.1` and `1.6.0` as kept and `1.7.0` and `1.5.0` as outdated, and deletes nothing.
- `reorder_versions.py` against the real `versions.json`: the order becomes `main`, the releases newest first, then the previews; all entries are preserved and the output is byte for byte what mike itself writes, so reordering causes no formatting difference.
- The 404 workflow was run against a worktree of the real `gh-pages` branch: it writes the page at the root of the branch, commits it once, and reports nothing to commit on a second run.
- `black`, `isort`, `flake8` and `yamllint` pass, at the versions this repository pins. Prettier and cspell were not run locally, because this machine has no Node.js: instead the tokens the new files introduce were checked against the dictionaries that `spell-check-differential` uses, and `.cspell.json` was checked against the output of the `format-cspell-json` hook.

**AI usage:** written with Claude Code in an interactive session. I set the retention rule, chose to move the logic out of shell and `jq` into tested Python, and directed several rounds of revision, including a multi-agent adversarial review of the branch whose findings I triaged.

**Self-review:** I read the tests and made sure they aligned with what I had in mind: main > 1.9.0, 1.8.1, 1.7.2 > pr-002 > pr-001 > random-branch-names. And it had diverse enough test cases.

**Verification:** beyond the runs listed above, each test was checked to fail for the right reason: eleven mutations of the source (`mike delete --push --all`, dropping `--push`, `mike deploy` in place of `mike delete`, `check=False`, reading `title` instead of `version`, removing the argument validation, removing the "nothing to delete" guard, reversing the release sort, and an off-by-one in the number of kept lines) were each applied to a copy and the suite failed on every one of them.

---

**Notes:** In the end, this increases the code size but makes ordering logic easier to understand and audit. So I think it's worth it.

It's just a dropdown menu order review after all, there is no way this task deserved this much attention...
