### PR TITLE
fix: load `.bashrc` just after ansible installation to use ansible command without logout

### DIFF
--- a/docs/installation/autoware/source-installation.md
+++ b/docs/installation/autoware/source-installation.md
@@ -39,6 +39,7 @@ sudo apt-get -y install git
 
    ```bash
    bash ansible/scripts/install-ansible.sh
+   source ~/.bashrc
    ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
    ansible-playbook autoware.dev_env.install_dev_env
    ```


### PR DESCRIPTION
## Description

Fix the source installation procedure as follows: without this fix (adding `source ~/.bashrc` just after installation of ansible), we cannot proceed to the next step.

```bash
   bash ansible/scripts/install-ansible.sh
   source ~/.bashrc    # <= Added!!
   ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
   ansible-playbook autoware.dev_env.install_dev_env
```

## How was this PR tested?

Tested by running the commands above on my local machine.