### PR TITLE
docs: drop tensorrt_rtmdet and trt_batched_nms references

### DIFF
--- a/docs/demos/planning-sim/index.md
+++ b/docs/demos/planning-sim/index.md
@@ -34,7 +34,6 @@ lidar_transfusion
 ptv3
 simpl_prediction
 tensorrt_bevdet
-tensorrt_rtmdet
 tensorrt_yolox
 traffic_light_classifier
 traffic_light_fine_detector

--- a/docs/demos/rosbag-replay-simulation.md
+++ b/docs/demos/rosbag-replay-simulation.md
@@ -35,7 +35,6 @@ lidar_transfusion
 ptv3
 simpl_prediction
 tensorrt_bevdet
-tensorrt_rtmdet
 tensorrt_yolox
 traffic_light_classifier
 traffic_light_fine_detector

--- a/docs/design/repository-structure.md
+++ b/docs/design/repository-structure.md
@@ -38,13 +38,11 @@ end
 %% ====================
 subgraph AutowareUniverse["Autoware Universe"]
     T4([tier4_autoware_msgs])
-    TBNMS([trt_batched_nms])
     CB([cuda_blackboard])
     MTB([managed_transform_buffer])
     U([autoware_universe])
 
     T4 --> U
-    TBNMS --> U
     CB --> U
     MTB --> U
 end


### PR DESCRIPTION
## Description

- `autoware_tensorrt_rtmdet` was never merged into `autoware_universe`. autowarefoundation/autoware_universe#8165 is closed and autowarefoundation/autoware_universe#7235 is closed as not planned, so the `tensorrt_rtmdet` model artifact and the `trt_batched_nms` TensorRT plugin are being removed from the meta-repo. Tracked in autowarefoundation/autoware#7252.

This PR removes the documentation references first, so the docs never describe an install that no longer happens.

Changes:

- `docs/demos/planning-sim/index.md` and `docs/demos/rosbag-replay-simulation.md`: drop `tensorrt_rtmdet` from the expected `~/autoware_data/ml_models` listing. Both pages tell the reader to compare that listing against their own install and are immediately followed by "If not, please, follow Manual downloading of artifacts", so leaving it in would make a correct install read as incomplete.
- `docs/design/repository-structure.md`: drop the `trt_batched_nms` mermaid node and its edge into `autoware_universe`. The existing note that some repositories are omitted to keep the diagram simple already covers the removal.

## How was this PR tested?

- Extracted every `{{ data_dir }}/<name>` from `ansible/roles/artifacts/tasks/main.yaml` on `autowarefoundation/autoware` `main`, minus the `tensorrt_rtmdet` block this change anticipates, and diffed it against the demo-page listing: identical, same order.
- `pre-commit run --files` on all three files: markdownlint and prettier pass.
- `git grep -in "rtmdet\|trt_batched_nms\|TBNMS"` returns nothing on the branch.

## Effects on system behavior

None, documentation only.
