### PR TITLE
docs(docker-installation): add missing ask-become-pass option for docker installation

### DIFF
--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -58,13 +58,13 @@ For the broader containerized-deployment story (deployment patterns, integration
    To install without **NVIDIA GPU** support:
 
    ```bash
-   ansible-playbook autoware.dev_env.install_docker --skip-tags nvidia
+   ansible-playbook autoware.dev_env.install_docker --skip-tags nvidia --ask-become-pass
    ```
 
    To download only the artifacts:
 
    ```bash
-   ansible-playbook autoware.dev_env.install_dev_env --tags artifacts
+   ansible-playbook autoware.dev_env.install_dev_env --tags artifacts --ask-become-pass
    ```
 
 !!! info

--- a/docs/installation/autoware/docker-installation.md
+++ b/docs/installation/autoware/docker-installation.md
@@ -52,7 +52,7 @@ For the broader containerized-deployment story (deployment patterns, integration
    ```bash
    bash ansible/scripts/install-ansible.sh
    ansible-galaxy collection install -f -r ansible-galaxy-requirements.yaml
-   ansible-playbook autoware.dev_env.install_docker
+   ansible-playbook autoware.dev_env.install_docker --ask-become-pass
    ```
 
    To install without **NVIDIA GPU** support:


### PR DESCRIPTION
## Description
The Docker installation guide instructs users to run the `install_docker` Ansible playbook without `--ask-become-pass`. That playbook performs privileged operations (installing Docker packages, adding the user to the `docker` group, setting up the NVIDIA container toolkit), so it fails with a "Missing sudo password" error unless Ansible is given a way to escalate.

This adds `--ask-become-pass` to the playbook invocation in the Docker installation instructions, matching the form already used in the demo guides (`docs/demos/planning-sim/index.md`, `docs/demos/rosbag-replay-simulation.md`).

## How was this PR tested?
Tested by the deploy-docs workflow to make sure that the page deploys correctly.
I have also tested the updated commands on my local machine and confirmed that they work fine.
